### PR TITLE
feature/511-rich-text-editor: fix route name 

### DIFF
--- a/src/app/core/core-routing.module.ts
+++ b/src/app/core/core-routing.module.ts
@@ -14,7 +14,7 @@ const routes: Routes = [
         path: 'challenges',
         children: [
           {
-            path: 'create',
+            path: 'new-challenge',
             loadComponent: async () =>
               (await import('../modules/challenge/components/challenge-form/challenge-form.component')).ChallengeFormComponent
           },


### PR DESCRIPTION
## Description:
This PR updates the route for challenge creation from `"create"` to `"new-challenge"` to prevent automatic GET requests when loading the form.

### Changes made:
- Renamed the route in `core-routing.module.ts` to avoid conflicts