### PR TITLE
Feature/221 edit button mentor

### DIFF
--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -55,7 +55,7 @@
     <button *ngIf="!challengeStarted"  class="btn btn-sm btn-primary" (click)="onStartChallenge()"> {{'modules.challenge.header.buttonStart' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
-    <button *ngIf="userRole === 'MENTOR' || userRole === 'ADMIN'" class="btn btn-sm btn-secondary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>
+    <button *ngIf="userRole === 'MENTOR' || userRole === 'ADMIN'" class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>
   </div>
  
    <!-- Si ya se envió la solución -->

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -55,7 +55,7 @@
     <button *ngIf="!challengeStarted"  class="btn btn-sm btn-primary" (click)="onStartChallenge()"> {{'modules.challenge.header.buttonStart' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
-    <button *ngIf="userRole === 'MENTOR'" class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>  
+    <button *ngIf="userRole === 'ADMIN'" class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>  
   </div>
  
    <!-- Si ya se envió la solución -->

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -55,7 +55,7 @@
     <button *ngIf="!challengeStarted"  class="btn btn-sm btn-primary" (click)="onStartChallenge()"> {{'modules.challenge.header.buttonStart' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
-    <button *ngIf="userRole === 'MENTOR' || userRole === 'ADMIN'" class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>
+    <button *ngIf="userRole === 'MENTOR'" class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>  
   </div>
  
    <!-- Si ya se envió la solución -->

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -55,6 +55,7 @@
     <button *ngIf="!challengeStarted"  class="btn btn-sm btn-primary" (click)="onStartChallenge()"> {{'modules.challenge.header.buttonStart' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
     <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
+    <button *ngIf="userRole === 'MENTOR' || userRole === 'ADMIN'" class="btn btn-sm btn-secondary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>
   </div>
  
    <!-- Si ya se envió la solución -->

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -22,6 +22,8 @@ export class ChallengeHeaderComponent implements OnInit {
   private readonly challengeService = inject(ChallengeService)
   private readonly authService = inject(AuthService);
   public userId: string | null = null;
+  public userRole: string | null = null;
+
 
   @Input() title = ''
   @Input() creation_date!: Date
@@ -63,6 +65,10 @@ export class ChallengeHeaderComponent implements OnInit {
         console.error("Could not get User ID");
       } 
     }); 
+
+    this.authService.getUserRole().subscribe(role => {
+      this.userRole = role
+    })
 
     // Verifica si el reto ya ha comenzado
     if (this.challengeStarted) {

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -38,6 +38,7 @@
                 "buttonSaveChallenge": "Guardar reto",
                 "buttonSendSolution": "Enviar solució",
                 "buttonCancel": "Cancel.lar",
+                "buttonEditChallenge": "Editar repte",
                 "solutionSend": "Solució enviada",
                 "login": "Iniciar sessió",
                 "logout": "Tancar sessió"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -38,6 +38,7 @@
                 "buttonSaveChallenge": "Save challenge",
                 "buttonSendSolution": "Send solution",
                 "buttonCancel": "Cancel",
+                "buttonEditChallenge": "Edit challenge",
                 "solutionSend": "Solution sent",
                 "login": "Log In",
                 "logout": "Log Out"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -38,6 +38,7 @@
                 "buttonSaveChallenge": "Guardar reto",
                 "buttonSendSolution": "Enviar solución",
                 "buttonCancel": "Cancelar",
+                "buttonEditChallenge": "Editar reto",
                 "solutionSend": "Solución enviada",
                 "login": "Iniciar sesión",
                 "logout": "Cerrar sesión"


### PR DESCRIPTION
**Related User Story** → This PR belongs to User Story #26 → "Como mentor/a, puedo editar los retos clicando un botón"

**This PR is part of HITO 1: Mentor/a: Creación y visualización de retos — Task in Taiga, Sprint 5 #221.**

**What has been done in this PR?**
- Display Edit Challenge button in the challenge detail view for users with role MENTOR.
- This button only appears if the user is authenticated and has one of these roles.
- The button style follows the Figma design (primary button).

![image](https://github.com/user-attachments/assets/d9671f4f-32a2-4932-b95c-cad8cd79ebe0)

**How to test it?**
- Login as a MENTOR user.
- Go to the challenge detail page.
- Check that the Edit Challenge button appears next to the other challenge actions (Save, Send Solution).
- The button should follow the design from Figma (primary button style).
- Clicking the button does nothing yet (navigation will be implemented in PR 222).

**Notes**
In this PR I have ONLY added the button.
The logic to navigate to the edit page will be done in a future PR. 
