### PR TITLE
Feature/262 highlight like icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ita-challenges-frontend",
       "version": "3.1.31-RELEASE",
       "dependencies": {
-        "@angular/animations": "^18.2.13",
+        "@angular/animations": "^18.0.2",
         "@angular/cdk": "^18.0.2",
         "@angular/common": "^18.0.2",
         "@angular/compiler": "^18.0.2",

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -46,15 +46,16 @@
         <div class="txt">0</div>
       </div>
 
-      <div class="stat d-flex align-items-center" 
-           [ngbTooltip]="'tooltips.favorites' | translate"
-           (click)="toggleFavorite($event)" style="cursor: pointer;">
+      <button class="stat d-flex align-items-center"
+        [ngbTooltip]="'tooltips.favorites' | translate"
+        (click)="toggleFavorite($event)"
+        style="cursor: pointer; background: none; border: none; padding: 0;">
         <div>
           <img *ngIf="!isFavorite" src="assets/img/icon/heart.svg" alt="Favorites">
           <img *ngIf="isFavorite" src="assets/img/icon/heart-filled.svg" alt="Favorites">
         </div>
         <div class="txt">{{favorites_count}}</div>
-      </div>
+      </button>
 
       <div class="stat d-flex align-items-center" [ngbTooltip]="'tooltips.creationDate' | translate">
         <div><img src="assets/img/icon/clock.svg" alt="Date"></div>

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -46,10 +46,9 @@
         <div class="txt">0</div>
       </div>
 
-      <button class="stat d-flex align-items-center"
+      <button class="stat d-flex align-items-center favorite-button"
         [ngbTooltip]="'tooltips.favorites' | translate"
-        (click)="toggleFavorite($event)"
-        style="cursor: pointer; background: none; border: none; padding: 0;">
+        (click)="toggleFavorite($event)">
         <div>
           <img *ngIf="!isFavorite" src="assets/img/icon/heart.svg" alt="Favorites">
           <img *ngIf="isFavorite" src="assets/img/icon/heart-filled.svg" alt="Favorites">

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -47,7 +47,8 @@
       </div>
 
       <div class="stat d-flex align-items-center" 
-           [ngbTooltip]="'tooltips.favorites' | translate">
+           [ngbTooltip]="'tooltips.favorites' | translate"
+           (click)="toggleFavorite($event)" style="cursor: pointer;">
         <div>
           <img *ngIf="!isFavorite" src="assets/img/icon/heart.svg" alt="Favorites">
           <img *ngIf="isFavorite" src="assets/img/icon/heart-filled.svg" alt="Favorites">

--- a/src/app/shared/components/challenge-card/challenge-card.component.scss
+++ b/src/app/shared/components/challenge-card/challenge-card.component.scss
@@ -105,3 +105,9 @@
 
 }
 }
+.favorite-button {
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+  }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -46,4 +46,9 @@ export class ChallengeCardComponent implements OnInit {
       this.favorites_count = parseInt(storedCount, 10);
     }
   }
+
+  toggleFavorite (event: MouseEvent): void {
+    event.stopPropagation()
+    this.isFavorite = !this.isFavorite
+  }
 }

--- a/src/assets/img/icon/heart-filled.svg
+++ b/src/assets/img/icon/heart-filled.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" fill="#FF385C"/>
     </g>


### PR DESCRIPTION
**Related User Story** → This PR belongs to User Story 251 → Likes y bookmarks

**What has been done in this PR?**

- Added visual change for the like icon (heart) in the challenge list view.

- When clicking the heart icon, it now turns red/pink to indicate it has been liked.

- This is a local UI change only, no connection to the backend yet.

- The heart icon reflects the like state temporarily for the current session.

**How to test it?**

1. Go to the challenge list page (home view).
2.  Click on the heart icon next to any challenge.
3. The icon should turn red/pink on click.
4. The like state is not saved permanently – refreshing the page resets it.

**Notes**

- This is only the first step of the like feature implementation.
- Backend connection and permanent like state will be handled in the next tasks.


![image](https://github.com/user-attachments/assets/92a23d91-51dc-476c-aa97-c4f8140da8ab)
