### PR TITLE
Feature/263 simulate like counter

### DIFF
--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -42,7 +42,7 @@
       <span class="stat" [ngbTooltip]="'tooltips.favorites' | translate" (click)="toggleFavorite()" style="cursor: pointer;">
         <img *ngIf="!isFavorite" src="assets/img/icon/heart.svg" alt="Add to favorites">
         <img *ngIf="isFavorite" src="assets/img/icon/heart-filled.svg" alt="Remove from favorites">
-        {{favorites_count}}
+        <span class="txt">{{favorites_count}}</span>
       </span>
       <span class="stat" [ngbTooltip]="'tooltips.creationDate' | translate">
         <img src="assets/img/icon/clock.svg" alt="Date">

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
@@ -90,3 +90,9 @@ h3 {
     margin-right: 4px;
   }
 }
+
+.stats .stat .txt {
+  display: inline-block;
+  min-width: 24px;
+  text-align: center;
+}

--- a/src/app/shared/components/challenge-card/challenge-card.component.scss
+++ b/src/app/shared/components/challenge-card/challenge-card.component.scss
@@ -67,6 +67,12 @@
   line-height: 16px;
   font-weight: 600;
   color: $gray-3;
+
+  .txt {
+    display: inline-block;
+    min-width: 20px;
+    text-align: center;
+  }
 }
 
 .favorite-icon {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -50,11 +50,6 @@ export class ChallengeCardComponent implements OnInit {
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
     this.isFavorite = !this.isFavorite
-
-    if (this.isFavorite) {
-      this.favorites_count++
-    } else {
-      this.favorites_count = Math.max(0, this.favorites_count - 1)
-    }
+    this.favorites_count = this.isFavorite ? this.favorites_count + 1 : Math.max(0, this.favorites_count - 1)
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -50,5 +50,11 @@ export class ChallengeCardComponent implements OnInit {
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
     this.isFavorite = !this.isFavorite
+
+    if (this.isFavorite) {
+      this.favorites_count++
+    } else {
+      this.favorites_count = Math.max(0, this.favorites_count - 1)
+    }
   }
 }


### PR DESCRIPTION
**Related User Story** → This PR belongs to User Story 251 → Likes y bookmarks

**What has been done in this PR?**

- Display a like counter next to the like icon in the challenge list.

- When clicking the like button:

If not liked, the icon turns pink/red and the counter increments by 1.

If already liked, the icon turns back to normal and the counter decrements by 1.

- The count change is simulated, not connected to the backend.

**How to test it?**

1. Go to the challenge list page.

2. Click on the like icon next to any challenge.

3. The heart icon should change color and the counter should increment.

4. Clicking again will revert the heart icon and decrement the counter.

**Notes**
- This implementation is only for visual and design validation.
- Backend connection will be handled in future tasks: 264, 265, 266.
- This branch was created from feature/262-highlight-like-icon, so it includes previous commits from that branch.

![image](https://github.com/user-attachments/assets/d9f0cfd5-a8f2-4b6f-a1c0-05f99fb61f73)

