### PR TITLE
Fix/261-Remove "Examples" and "Notes" Fields from Challenge View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [ita-challenges-frontend-3.1.33-RELEASE] (2025-04-10) (fix#261)
+
+- Remove examples and notes sections from challenge info component
+
 ### [ita-challenges-frontend-3.1.32-RELEASE] (2025-04-10) (feature#571)
 
 - Added logout functionality

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.html
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.html
@@ -37,24 +37,6 @@
              <p [innerHTML]="description | dynamicTranslate "></p>
 
             </div>
-
-            <!-- Examples -->
-            <div class="pb-1">
-              <h3>{{ "modules.challenge.info.examples" | translate }}</h3>
-              <ul>
-                <ng-container *ngFor="let example of examples">
-                  <li class="mb-1" *ngIf="example.example_text">
-                    {{ example.example_text | dynamicTranslate }}
-                  </li>
-                </ng-container>
-              </ul>
-            </div>
-
-            <!-- Notes -->
-            <div class="pb-1">
-              <h3>{{ "modules.challenge.info.notes" | translate }}</h3>
-              <p>{{ notes | dynamicTranslate }}</p>
-            </div>
           </div>
 
           <div class="editor-section" *ngIf="isEditorChallengeVisible">

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -61,8 +61,6 @@ implements OnInit {
   @Input() detail!: ChallengeDetails
   @Input() solutions: string[] = []
   @Input() description!: string
-  @Input() examples: Example[] = []
-  @Input() notes!: string
   @Input() popularity!: number
   @Input() languages: Language[] = []
   @Input() activeId: ChallengeTab = ChallengeTab.DETAILS

--- a/src/app/modules/challenge/components/challenge/challenge.component.html
+++ b/src/app/modules/challenge/components/challenge/challenge.component.html
@@ -13,8 +13,6 @@
     <app-challenge-info
         [detail]="detail"
         [description]="description"
-        [examples]="examples"
-        [notes]="notes"
         [popularity]="popularity"
         [languages]="languages"
         [activeId]="activeId"


### PR DESCRIPTION
This PR removes the "Examples" and "Notes" fields from the challenge-info view, as these fields:
- Are not being populated during challenge creation
- Will be consolidated into the "Description" field using rich text formatting

## Changes Made
- Removed "Examples" and "Notes" sections from challenge detail view
- Simplified UI to show only the description field with rich text support
- Cleaned up related code and dependencies


Related to user history: #250 (Review login errors and mentor workflow)