### PR TITLE
Feature/264 send like to backend

### DIFF
--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -164,9 +164,14 @@ export class ChallengeHeaderComponent implements OnInit {
     this.isFavorite = !this.isFavorite
     this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
-      this.removeFromFavorites()
+      this.challengeService.addToFavorites(this.idChallenge).subscribe({
+        next: () => {
+        },
+        error: () => {
+        }
+      })
     } else {
-      this.addToFavorites()
+    // TODO: Implementar removeFromFavorites en la PR correspondiente
     }
   }
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -161,6 +161,8 @@ export class ChallengeHeaderComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
+    this.isFavorite = !this.isFavorite
+    this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
       this.removeFromFavorites()
     } else {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -157,7 +157,10 @@ export class ChallengeHeaderComponent implements OnInit {
     this.openSendSolutionModal()
   }
 
-  toggleFavorite(): void {
+  toggleFavorite (): void {
+    if (!this.authService.isUserLoggedIn()) {
+      return
+    }
     if (this.isFavorite) {
       this.removeFromFavorites()
     } else {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/semi */
+/* eslint-disable @typescript-eslint/space-before-function-paren */
 import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -1,31 +1,35 @@
 import { ChallengeService } from './challenge.service'
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing'
 import { HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
-import { TestBed, inject } from '@angular/core/testing'
+import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing'
 import { environment } from 'src/environments/environment'
 import { type Itinerary } from '../models/itinerary.interface'
 import { type CreateChallenge } from '../models/create-challenge.interface'
 import { type FavoriteResponse } from '../models/favorite-response.interface'
-import { fakeAsync, tick } from '@angular/core/testing'
+import { AuthService } from './auth.service'
 
 /* Observable Test, see https://docs.angular.lat/guide/testing-components-scenarios */
+
+const authServiceStub = {
+  getAuthHeaders: () => ({ Authorization: 'Bearer mock-token' })
+}
+
 describe('ChallengeService', () => {
   let service: ChallengeService
-  // let httpMock: HttpTestingController
-  // let scheduler: TestScheduler
   let httpClient: HttpClient
-  let httpClientMock: HttpTestingController
+  let httpMock: HttpTestingController
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [],
-      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
     })
-
-    // Inject the http service and test controller for each test
-    httpClient = TestBed.inject(HttpClient) // TestBed.inject is used to inject into the test suite
-    httpClientMock = TestBed.inject(HttpTestingController)
     service = TestBed.inject(ChallengeService)
+    httpClient = TestBed.inject(HttpClient)
+    httpMock = TestBed.inject(HttpTestingController)
   })
 
   /*
@@ -65,7 +69,7 @@ describe('ChallengeService', () => {
       done()
     })
 
-    const req = httpClientMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
+    const req = httpMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
     expect(req.request.method).toEqual('GET')
     req.flush(mockData)
   })
@@ -81,7 +85,7 @@ describe('ChallengeService', () => {
       }
     })
 
-    const req = httpClientMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
+    const req = httpMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
     expect(req.request.method).toEqual('GET')
 
     req.error(new ProgressEvent('error', {
@@ -90,7 +94,7 @@ describe('ChallengeService', () => {
       total: 0
     }))
 
-    httpClientMock.verify()
+    httpMock.verify()
   })
   it('should call getAllLanguages() and return data', inject([ChallengeService, HttpTestingController],
     (service: ChallengeService, httpMock: HttpTestingController) => {
@@ -130,136 +134,98 @@ describe('ChallengeService', () => {
       done()
     })
 
-    const req = httpClientMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}`)
+    const req = httpMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}`)
     expect(req.request.method).toBe('POST')
     expect(req.request.body).toEqual(mockChallenge)
 
     req.flush(mockResponse)
-    httpClientMock.verify()
+    httpMock.verify()
   })
 
   // Tests for mocked favorites functionality
-  describe('Favorites functionality', () => {
-    const testChallengeId = 'test-challenge-123'
-    
+  describe('removeFromFavorites (mock)', () => {
+    const testId = 'test-challenge-123'
+
     beforeEach(() => {
-      // Clear localStorage before each test
-      localStorage.removeItem(`is_favorite_${testChallengeId}`)
-      localStorage.removeItem(`favorites_count_${testChallengeId}`)
+      localStorage.removeItem(`is_favorite_${testId}`)
+      localStorage.removeItem(`favorites_count_${testId}`)
     })
-    
-    it('should add a challenge to favorites', fakeAsync(() => {
-      // Initial state should be empty
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBeNull()
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBeNull()
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
-      })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(true)
-      expect(result?.timesFavorited).toBe(1)
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('true')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('1')
-    }))
-    
-    it('should increment favorites count when adding multiple times', fakeAsync(() => {
-      // Set initial state
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '5')
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
-      })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(true)
-      expect(result?.timesFavorited).toBe(6) // Should increment from 5 to 6
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('true')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('6')
-    }))
-    
+
     it('should remove a challenge from favorites', fakeAsync(() => {
-      // Set initial state
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '3')
-      
+      localStorage.setItem(`is_favorite_${testId}`, 'true')
+      localStorage.setItem(`favorites_count_${testId}`, '3')
       let result: FavoriteResponse | undefined
-      
-      service.removeFromFavorites(testChallengeId).subscribe(response => {
-        result = response
+
+      service.removeFromFavorites(testId).subscribe((r) => {
+        result = r
       })
-      
-      // Simulate the delay
       tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(false)
-      expect(result?.timesFavorited).toBe(2) // Should decrement from 3 to 2
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('false')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('2')
+
+      expect(result).toEqual({ isFavorite: false, timesFavorited: 2 })
+      expect(localStorage.getItem(`is_favorite_${testId}`)).toBe('false')
+      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('2')
     }))
-    
+
     it('should not decrement below zero when removing favorites', fakeAsync(() => {
-      // Set initial state with zero count
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '0')
-      
+      localStorage.setItem(`is_favorite_${testId}`, 'true')
+      localStorage.setItem(`favorites_count_${testId}`, '0')
       let result: FavoriteResponse | undefined
-      
-      service.removeFromFavorites(testChallengeId).subscribe(response => {
-        result = response
+      service.removeFromFavorites(testId).subscribe(r => {
+        result = r
       })
-      
-      // Simulate the delay
       tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(false)
-      expect(result?.timesFavorited).toBe(0) // Should remain at 0
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('false')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('0')
+
+      expect(result).toEqual({ isFavorite: false, timesFavorited: 0 })
+      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('0')
     }))
-    
-    it('should handle empty localStorage when getting mock favorite count', fakeAsync(() => {
-      // Ensure localStorage is empty
-      localStorage.removeItem(`favorites_count_${testChallengeId}`)
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
+  })
+  describe('addToFavorites (real HTTP)', () => {
+    const testId = 'test-challenge-123'
+
+    beforeEach(() => {
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withInterceptorsFromDi()),
+          provideHttpClientTesting(),
+          { provide: AuthService, useValue: authServiceStub }
+        ]
       })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response starts from 0
-      expect(result).toBeDefined()
-      expect(result?.timesFavorited).toBe(1) // Should start from 0 and increment to 1
-    }))
+      service = TestBed.inject(ChallengeService)
+      httpMock = TestBed.inject(HttpTestingController)
+    })
+
+    afterEach(() => {
+      httpMock.verify()
+    })
+
+    it('should POST and return backend response', (done) => {
+      const mockResp: FavoriteResponse = { isFavorite: true, timesFavorited: 42 }
+
+      service.addToFavorites(testId).subscribe((res) => {
+        expect(res).toEqual(mockResp)
+        done()
+      })
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      expect(req.request.method).toBe('POST')
+      expect(req.request.body).toEqual({})
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
+      req.flush(mockResp)
+    })
+
+    it('should catch error and return default', (done) => {
+      service.addToFavorites(testId).subscribe((res) => {
+        expect(res).toEqual({ isFavorite: false, timesFavorited: 0 })
+        done()
+      })
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      req.flush({ message: 'Server error' }, { status: 500, statusText: 'Error' })
+    })
   })
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -1,6 +1,8 @@
+/* eslint-disable padded-blocks */
+/* eslint-disable @typescript-eslint/semi */
 import { Inject, Injectable, inject } from '@angular/core'
 import { Observable, catchError, BehaviorSubject, of } from 'rxjs'
-import { delay } from 'rxjs/operators'
+import { delay, map } from 'rxjs/operators'
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http'
 import { type Itinerary } from '../models/itinerary.interface'
 import { environment } from 'src/environments/environment'
@@ -9,6 +11,7 @@ import { type Language } from '../models/language.model'
 import { type FavoriteResponse } from '../models/favorite-response.interface'
 import { type CreateChallenge } from '../models/create-challenge.interface'
 import { CookieService } from 'ngx-cookie-service'
+import { AuthService } from './auth.service'
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +20,7 @@ export class ChallengeService {
   private challengeStarted: boolean = false
   private readonly challengeStartedSubject = new BehaviorSubject<boolean>(this.getChallengeStartedFromStorage())
   private readonly cookieService = inject(CookieService)
+  private readonly authService = inject(AuthService)
 
   constructor (@Inject(HttpClient) private readonly http: HttpClient) {
     this.checkChallengeStartedFromStorage()
@@ -97,21 +101,28 @@ export class ChallengeService {
     })
   }
 
-  // Mocked version for frontend testing
-  addToFavorites(challengeId: string): Observable<FavoriteResponse> {
-  
-    const currentCount = this.getMockFavoriteCount(challengeId);
-    
-    const mockResponse: FavoriteResponse = {
-      isFavorite: true,
-      timesFavorited: currentCount + 1
-    }
-    
-    localStorage.setItem(`is_favorite_${challengeId}`, 'true');
-   
-    localStorage.setItem(`favorites_count_${challengeId}`, mockResponse.timesFavorited.toString());
-    
-    return of(mockResponse).pipe(delay(300));
+  addToFavorites (challengeId: string): Observable<FavoriteResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    console.log('Enviando petición POST a:', url);
+    console.log('Headers:', headers);
+    return this.http.post<FavoriteResponse>(
+      url,
+      {},
+      { headers }
+    ).pipe(
+      map(response => {
+        console.log('Respuesta del backend (Add to favorites):', response);
+        return response;
+      }),
+      catchError(error => {
+        console.error('Error al añadir a favoritos:', error);
+        return of({ isFavorite: false, timesFavorited: 0 });
+      })
+    );
   }
 
   // Mocked version for frontend testing

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -107,19 +107,16 @@ export class ChallengeService {
       ...this.authService.getAuthHeaders()
     };
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
-    console.log('Enviando petición POST a:', url);
-    console.log('Headers:', headers);
     return this.http.post<FavoriteResponse>(
       url,
       {},
       { headers }
     ).pipe(
       map(response => {
-        console.log('Respuesta del backend (Add to favorites):', response);
         return response;
       }),
       catchError(error => {
-        console.error('Error al añadir a favoritos:', error);
+        console.error('Error adding to favorites:', error);
         return of({ isFavorite: false, timesFavorited: 0 });
       })
     );

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -67,7 +67,7 @@ export class ChallengeCardComponent implements OnInit {
         }
       })
     } else {
-      console.log('Aquí llamaremos a removeFromFavorites más adelante.')
+    // TODO: Implement removeFromFavorites functionality
     }
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, inject, OnInit } from '@angular/core'
 import { StarterService } from '../../../services/starter.service'
 import { TranslateService } from '@ngx-translate/core'
 import { ChallengeService } from '../../../services/challenge.service'
+import { AuthService } from 'src/app/services/auth.service'
 
 @Component({
   selector: 'app-challenge-card',
@@ -13,6 +14,7 @@ export class ChallengeCardComponent implements OnInit {
   private readonly starterService = inject(StarterService)
   private readonly translate = inject(TranslateService)
   private readonly challengeService = inject(ChallengeService)
+  private readonly authService = inject(AuthService)
 
   @Input() title: string = ''
   @Input() languages: any = []
@@ -49,7 +51,26 @@ export class ChallengeCardComponent implements OnInit {
 
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
+    // Verificamos si el usuario está logueado
+    if (!this.authService.isUserLoggedIn()) {
+      console.log('User not logged in. Favorite action is blocked.')
+      return // No hacemos nada si no está logueado
+    }
+    // Cambiamos visualmente de inmediato
     this.isFavorite = !this.isFavorite
     this.favorites_count = this.isFavorite ? this.favorites_count + 1 : Math.max(0, this.favorites_count - 1)
+    // Llamamos al backend según el estado
+    if (this.isFavorite) {
+      this.challengeService.addToFavorites(this.id).subscribe({
+        next: response => {
+          console.log('Favorite added:', response)
+        },
+        error: error => {
+          console.error('Error adding favorite:', error)
+        }
+      })
+    } else {
+      console.log('Aquí llamaremos a removeFromFavorites más adelante.')
+    }
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -51,12 +51,9 @@ export class ChallengeCardComponent implements OnInit {
 
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
-    // Verificamos si el usuario está logueado
     if (!this.authService.isUserLoggedIn()) {
-      console.log('User not logged in. Favorite action is blocked.')
-      return // No hacemos nada si no está logueado
+      return
     }
-    // Cambiamos visualmente de inmediato
     this.isFavorite = !this.isFavorite
     this.favorites_count = this.isFavorite ? this.favorites_count + 1 : Math.max(0, this.favorites_count - 1)
     // Llamamos al backend según el estado


### PR DESCRIPTION
**Related User Story** → This PR belongs to User Story 251 → Likes y bookmarks

**What has been done in this PR?** → Implemented the connection to the backend when clicking the like button in the challenge list and challenge detail views.

**When a user clicks the like button:**

- If not logged in, the action is blocked.
- If logged in, the like action sends a request to the backend (addToFavorites).
- The heart icon changes color and the like counter updates immediately for a better user experience.

**Note**: The actual backend response is not yet processed; it will be handled in future tasks.

**How to test it?**

1. Go to the challenge list or challenge detail page.
2.  Ensure you are logged in.
3. Click the heart icon to like a challenge.
4. The icon should turn pink/red, and the counter should increment.
5. Open browser dev tools and check that the backend request is made successfully.

**Notes**

- The backend response is not yet handled, and removeFromFavorites is not implemented. These will be addressed in future PR.
- Temporary console.log statements have been left intentionally for backend debugging. They will be removed in the final step of this user story.


