### PR TITLE
Feature/265 update like icon backend

### DIFF
--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -155,13 +155,14 @@ export class ChallengeHeaderComponent implements OnInit {
       return
     }
     this.isFavorite = !this.isFavorite
-    this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
         next: response => {
           console.log('Favorite added:', response)
+          this.favorites_count = response.timesFavorited;
         },
         error: () => {
+
         }
       })
     } else {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -58,7 +58,19 @@ export class ChallengeHeaderComponent implements OnInit {
     const savedSolutions = JSON.parse(localStorage.getItem('solutions') ?? '[]') as string[]
     this.solutionSent = savedSolutions.includes(this.idChallenge)
 
-    this.checkFavoriteStatus()
+    if (!this.authService.isUserLoggedIn()) {
+      return
+    }
+    this.challengeService.getFavoriteStatus(this.idChallenge).subscribe({
+      next: resp => {
+        this.isFavorite = resp.isFavorite
+        this.favorites_count = resp.timesFavorited
+      },
+      error: err => {
+        console.error('Error fetching favorite status:', err)
+        this.isFavorite = false
+      }
+    })
 
     this.solutionService.challengeCompleted$.subscribe({
       next: (challengeId: string) => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -157,9 +157,14 @@ export class ChallengeHeaderComponent implements OnInit {
     this.isFavorite = !this.isFavorite
     this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
-      this.removeFromFavorites()
+      this.challengeService.addToFavorites(this.idChallenge).subscribe({
+        next: () => {
+        },
+        error: () => {
+        }
+      })
     } else {
-      this.addToFavorites()
+    // TODO: Implementar removeFromFavorites en la PR correspondiente
     }
   }
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -157,7 +157,6 @@ export class ChallengeHeaderComponent implements OnInit {
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
         next: response => {
-          console.log('Favorite added:', response)
           this.isFavorite = response.isFavorite
           this.favorites_count = response.timesFavorited;
         },

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -150,7 +150,10 @@ export class ChallengeHeaderComponent implements OnInit {
     this.openSendSolutionModal()
   }
 
-  toggleFavorite(): void {
+  toggleFavorite (): void {
+    if (!this.authService.isUserLoggedIn()) {
+      return
+    }
     if (this.isFavorite) {
       this.removeFromFavorites()
     } else {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -158,7 +158,8 @@ export class ChallengeHeaderComponent implements OnInit {
     this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
-        next: () => {
+        next: response => {
+          console.log('Favorite added:', response)
         },
         error: () => {
         }

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -154,11 +154,11 @@ export class ChallengeHeaderComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
-    this.isFavorite = !this.isFavorite
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
         next: response => {
           console.log('Favorite added:', response)
+          this.isFavorite = response.isFavorite
           this.favorites_count = response.timesFavorited;
         },
         error: error => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -154,6 +154,8 @@ export class ChallengeHeaderComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
+    this.isFavorite = !this.isFavorite
+    this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
       this.removeFromFavorites()
     } else {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -161,8 +161,8 @@ export class ChallengeHeaderComponent implements OnInit {
           console.log('Favorite added:', response)
           this.favorites_count = response.timesFavorited;
         },
-        error: () => {
-
+        error: error => {
+          console.error('Error adding favorite:', error)
         }
       })
     } else {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -162,6 +162,7 @@ export class ChallengeHeaderComponent implements OnInit {
           this.favorites_count = response.timesFavorited;
         },
         error: error => {
+          this.isFavorite = false
           console.error('Error adding favorite:', error)
         }
       })

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/semi */
+/* eslint-disable @typescript-eslint/space-before-function-paren */
 import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -1,31 +1,35 @@
 import { ChallengeService } from './challenge.service'
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing'
 import { HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
-import { TestBed, inject } from '@angular/core/testing'
+import { TestBed, inject, fakeAsync, tick } from '@angular/core/testing'
 import { environment } from 'src/environments/environment'
 import { type Itinerary } from '../models/itinerary.interface'
 import { type CreateChallenge } from '../models/create-challenge.interface'
 import { type FavoriteResponse } from '../models/favorite-response.interface'
-import { fakeAsync, tick } from '@angular/core/testing'
+import { AuthService } from './auth.service'
 
 /* Observable Test, see https://docs.angular.lat/guide/testing-components-scenarios */
+
+const authServiceStub = {
+  getAuthHeaders: () => ({ Authorization: 'Bearer mock-token' })
+}
+
 describe('ChallengeService', () => {
   let service: ChallengeService
-  // let httpMock: HttpTestingController
-  // let scheduler: TestScheduler
   let httpClient: HttpClient
-  let httpClientMock: HttpTestingController
+  let httpMock: HttpTestingController
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [],
-      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceStub }
+      ]
     })
-
-    // Inject the http service and test controller for each test
-    httpClient = TestBed.inject(HttpClient) // TestBed.inject is used to inject into the test suite
-    httpClientMock = TestBed.inject(HttpTestingController)
     service = TestBed.inject(ChallengeService)
+    httpClient = TestBed.inject(HttpClient)
+    httpMock = TestBed.inject(HttpTestingController)
   })
 
   /*
@@ -65,7 +69,7 @@ describe('ChallengeService', () => {
       done()
     })
 
-    const req = httpClientMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
+    const req = httpMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
     expect(req.request.method).toEqual('GET')
     req.flush(mockData)
   })
@@ -81,7 +85,7 @@ describe('ChallengeService', () => {
       }
     })
 
-    const req = httpClientMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
+    const req = httpMock.expectOne(environment.BACKEND_ITA_SSO_BASE_URL.concat(environment.BACKEND_SSO_ITINERARIES))
     expect(req.request.method).toEqual('GET')
 
     req.error(new ProgressEvent('error', {
@@ -90,7 +94,7 @@ describe('ChallengeService', () => {
       total: 0
     }))
 
-    httpClientMock.verify()
+    httpMock.verify()
   })
   it('should call getAllLanguages() and return data', inject([ChallengeService, HttpTestingController],
     (service: ChallengeService, httpMock: HttpTestingController) => {
@@ -130,136 +134,98 @@ describe('ChallengeService', () => {
       done()
     })
 
-    const req = httpClientMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}`)
+    const req = httpMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}`)
     expect(req.request.method).toBe('POST')
     expect(req.request.body).toEqual(mockChallenge)
 
     req.flush(mockResponse)
-    httpClientMock.verify()
+    httpMock.verify()
   })
 
   // Tests for mocked favorites functionality
-  describe('Favorites functionality', () => {
-    const testChallengeId = 'test-challenge-123'
-    
+  describe('removeFromFavorites (mock)', () => {
+    const testId = 'test-challenge-123'
+
     beforeEach(() => {
-      // Clear localStorage before each test
-      localStorage.removeItem(`is_favorite_${testChallengeId}`)
-      localStorage.removeItem(`favorites_count_${testChallengeId}`)
+      localStorage.removeItem(`is_favorite_${testId}`)
+      localStorage.removeItem(`favorites_count_${testId}`)
     })
-    
-    it('should add a challenge to favorites', fakeAsync(() => {
-      // Initial state should be empty
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBeNull()
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBeNull()
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
-      })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(true)
-      expect(result?.timesFavorited).toBe(1)
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('true')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('1')
-    }))
-    
-    it('should increment favorites count when adding multiple times', fakeAsync(() => {
-      // Set initial state
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '5')
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
-      })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(true)
-      expect(result?.timesFavorited).toBe(6) // Should increment from 5 to 6
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('true')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('6')
-    }))
-    
+
     it('should remove a challenge from favorites', fakeAsync(() => {
-      // Set initial state
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '3')
-      
+      localStorage.setItem(`is_favorite_${testId}`, 'true')
+      localStorage.setItem(`favorites_count_${testId}`, '3')
       let result: FavoriteResponse | undefined
-      
-      service.removeFromFavorites(testChallengeId).subscribe(response => {
-        result = response
+
+      service.removeFromFavorites(testId).subscribe((r) => {
+        result = r
       })
-      
-      // Simulate the delay
       tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(false)
-      expect(result?.timesFavorited).toBe(2) // Should decrement from 3 to 2
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('false')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('2')
+
+      expect(result).toEqual({ isFavorite: false, timesFavorited: 2 })
+      expect(localStorage.getItem(`is_favorite_${testId}`)).toBe('false')
+      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('2')
     }))
-    
+
     it('should not decrement below zero when removing favorites', fakeAsync(() => {
-      // Set initial state with zero count
-      localStorage.setItem(`is_favorite_${testChallengeId}`, 'true')
-      localStorage.setItem(`favorites_count_${testChallengeId}`, '0')
-      
+      localStorage.setItem(`is_favorite_${testId}`, 'true')
+      localStorage.setItem(`favorites_count_${testId}`, '0')
       let result: FavoriteResponse | undefined
-      
-      service.removeFromFavorites(testChallengeId).subscribe(response => {
-        result = response
+      service.removeFromFavorites(testId).subscribe(r => {
+        result = r
       })
-      
-      // Simulate the delay
       tick(300)
-      
-      // Check the response
-      expect(result).toBeDefined()
-      expect(result?.isFavorite).toBe(false)
-      expect(result?.timesFavorited).toBe(0) // Should remain at 0
-      
-      // Check localStorage was updated correctly
-      expect(localStorage.getItem(`is_favorite_${testChallengeId}`)).toBe('false')
-      expect(localStorage.getItem(`favorites_count_${testChallengeId}`)).toBe('0')
+
+      expect(result).toEqual({ isFavorite: false, timesFavorited: 0 })
+      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('0')
     }))
-    
-    it('should handle empty localStorage when getting mock favorite count', fakeAsync(() => {
-      // Ensure localStorage is empty
-      localStorage.removeItem(`favorites_count_${testChallengeId}`)
-      
-      let result: FavoriteResponse | undefined
-      
-      service.addToFavorites(testChallengeId).subscribe(response => {
-        result = response
+  })
+  describe('addToFavorites (real HTTP)', () => {
+    const testId = 'test-challenge-123'
+
+    beforeEach(() => {
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withInterceptorsFromDi()),
+          provideHttpClientTesting(),
+          { provide: AuthService, useValue: authServiceStub }
+        ]
       })
-      
-      // Simulate the delay
-      tick(300)
-      
-      // Check the response starts from 0
-      expect(result).toBeDefined()
-      expect(result?.timesFavorited).toBe(1) // Should start from 0 and increment to 1
-    }))
+      service = TestBed.inject(ChallengeService)
+      httpMock = TestBed.inject(HttpTestingController)
+    })
+
+    afterEach(() => {
+      httpMock.verify()
+    })
+
+    it('should POST and return backend response', (done) => {
+      const mockResp: FavoriteResponse = { isFavorite: true, timesFavorited: 42 }
+
+      service.addToFavorites(testId).subscribe((res) => {
+        expect(res).toEqual(mockResp)
+        done()
+      })
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      expect(req.request.method).toBe('POST')
+      expect(req.request.body).toEqual({})
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
+      req.flush(mockResp)
+    })
+
+    it('should catch error and return default', (done) => {
+      service.addToFavorites(testId).subscribe((res) => {
+        expect(res).toEqual({ isFavorite: false, timesFavorited: 0 })
+        done()
+      })
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      req.flush({ message: 'Server error' }, { status: 500, statusText: 'Error' })
+    })
   })
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -138,6 +138,22 @@ export class ChallengeService {
     return of(mockResponse).pipe(delay(300));
   }
 
+  getFavoriteStatus (challengeId: string): Observable<FavoriteResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    return this.http
+      .get<FavoriteResponse>(url, { headers })
+      .pipe(
+        catchError(err => {
+          console.error('Error fetching favorite status:', err);
+          return of({ isFavorite: false, timesFavorited: 0 });
+        })
+      );
+  }
+
   // Helper methods for mock implementation
   private getMockFavoriteCount(challengeId: string): number {
     const key = `favorites_count_${challengeId}`

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -1,6 +1,8 @@
+/* eslint-disable padded-blocks */
+/* eslint-disable @typescript-eslint/semi */
 import { Inject, Injectable, inject } from '@angular/core'
 import { Observable, catchError, BehaviorSubject, of } from 'rxjs'
-import { delay } from 'rxjs/operators'
+import { delay, map } from 'rxjs/operators'
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http'
 import { type Itinerary } from '../models/itinerary.interface'
 import { environment } from 'src/environments/environment'
@@ -9,6 +11,7 @@ import { type Language } from '../models/language.model'
 import { type FavoriteResponse } from '../models/favorite-response.interface'
 import { type CreateChallenge } from '../models/create-challenge.interface'
 import { CookieService } from 'ngx-cookie-service'
+import { AuthService } from './auth.service'
 
 @Injectable({
   providedIn: 'root'
@@ -17,6 +20,7 @@ export class ChallengeService {
   private challengeStarted: boolean = false
   private readonly challengeStartedSubject = new BehaviorSubject<boolean>(this.getChallengeStartedFromStorage())
   private readonly cookieService = inject(CookieService)
+  private readonly authService = inject(AuthService)
 
   constructor (@Inject(HttpClient) private readonly http: HttpClient) {
     this.checkChallengeStartedFromStorage()
@@ -97,21 +101,28 @@ export class ChallengeService {
     })
   }
 
-  // Mocked version for frontend testing
-  addToFavorites(challengeId: string): Observable<FavoriteResponse> {
-  
-    const currentCount = this.getMockFavoriteCount(challengeId);
-    
-    const mockResponse: FavoriteResponse = {
-      isFavorite: true,
-      timesFavorited: currentCount + 1
-    }
-    
-    localStorage.setItem(`is_favorite_${challengeId}`, 'true');
-   
-    localStorage.setItem(`favorites_count_${challengeId}`, mockResponse.timesFavorited.toString());
-    
-    return of(mockResponse).pipe(delay(300));
+  addToFavorites (challengeId: string): Observable<FavoriteResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    console.log('Enviando petición POST a:', url);
+    console.log('Headers:', headers);
+    return this.http.post<FavoriteResponse>(
+      url,
+      {},
+      { headers }
+    ).pipe(
+      map(response => {
+        console.log('Respuesta del backend (Add to favorites):', response);
+        return response;
+      }),
+      catchError(error => {
+        console.error('Error al añadir a favoritos:', error);
+        return of({ isFavorite: false, timesFavorited: 0 });
+      })
+    );
   }
 
   // Mocked version for frontend testing

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -107,19 +107,16 @@ export class ChallengeService {
       ...this.authService.getAuthHeaders()
     };
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
-    console.log('Enviando petición POST a:', url);
-    console.log('Headers:', headers);
     return this.http.post<FavoriteResponse>(
       url,
       {},
       { headers }
     ).pipe(
       map(response => {
-        console.log('Respuesta del backend (Add to favorites):', response);
         return response;
       }),
       catchError(error => {
-        console.error('Error al añadir a favoritos:', error);
+        console.error('Error adding to favorites:', error);
         return of({ isFavorite: false, timesFavorited: 0 });
       })
     );

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -54,11 +54,11 @@ export class ChallengeCardComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
-    this.isFavorite = !this.isFavorite
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
           console.log('Favorite added:', response)
+          this.isFavorite = response.isFavorite
           this.favorites_count = response.timesFavorited;
         },
         error: error => {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -59,9 +59,11 @@ export class ChallengeCardComponent implements OnInit {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
           console.log('Favorite added:', response)
+          this.favorites_count = response.timesFavorited;
         },
         error: error => {
           console.error('Error adding favorite:', error)
+          this.favorites_count -= 1;
         }
       })
     } else {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, inject, OnInit } from '@angular/core'
 import { StarterService } from '../../../services/starter.service'
 import { TranslateService } from '@ngx-translate/core'
 import { ChallengeService } from '../../../services/challenge.service'
+import {AuthService} from "../../../services/auth.service";
 
 @Component({
   selector: 'app-challenge-card',

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -51,15 +51,11 @@ export class ChallengeCardComponent implements OnInit {
 
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
-    // Verificamos si el usuario está logueado
     if (!this.authService.isUserLoggedIn()) {
-      console.log('User not logged in. Favorite action is blocked.')
-      return // No hacemos nada si no está logueado
+      return
     }
-    // Cambiamos visualmente de inmediato
     this.isFavorite = !this.isFavorite
     this.favorites_count += this.isFavorite ? 1 : -1
-    // Llamamos al backend según el estado
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -55,7 +55,6 @@ export class ChallengeCardComponent implements OnInit {
       return
     }
     this.isFavorite = !this.isFavorite
-    this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
@@ -64,7 +63,6 @@ export class ChallengeCardComponent implements OnInit {
         },
         error: error => {
           console.error('Error adding favorite:', error)
-          this.favorites_count -= 1;
         }
       })
     } else {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -25,9 +25,20 @@ export class ChallengeCardComponent implements OnInit {
   @Input() favorites_count: number = 0
   isFavorite: boolean = false;
 
-  ngOnInit(): void {
-    // Check if challenge is favorited in localStorage
-    this.checkFavoriteStatus();
+  ngOnInit (): void {
+    if (!this.authService.isUserLoggedIn()) {
+      return
+    }
+    this.challengeService.getFavoriteStatus(this.id).subscribe({
+      next: resp => {
+        this.isFavorite = resp.isFavorite
+        this.favorites_count = resp.timesFavorited
+      },
+      error: err => {
+        console.error('Error fetching favorite status:', err)
+        this.isFavorite = false
+      }
+    })
   }
 
   get currentLang (): string {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -62,6 +62,7 @@ export class ChallengeCardComponent implements OnInit {
           this.favorites_count = response.timesFavorited;
         },
         error: error => {
+          this.isFavorite = false
           console.error('Error adding favorite:', error)
         }
       })

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -66,7 +66,7 @@ export class ChallengeCardComponent implements OnInit {
         }
       })
     } else {
-      console.log('Aquí llamaremos a removeFromFavorites más adelante.')
+    // TODO: Implement removeFromFavorites functionality
     }
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, inject, OnInit } from '@angular/core'
 import { StarterService } from '../../../services/starter.service'
 import { TranslateService } from '@ngx-translate/core'
 import { ChallengeService } from '../../../services/challenge.service'
+import { AuthService } from 'src/app/services/auth.service'
 
 @Component({
   selector: 'app-challenge-card',
@@ -13,6 +14,7 @@ export class ChallengeCardComponent implements OnInit {
   private readonly starterService = inject(StarterService)
   private readonly translate = inject(TranslateService)
   private readonly challengeService = inject(ChallengeService)
+  private readonly authService = inject(AuthService)
 
   @Input() title: string = ''
   @Input() languages: any = []
@@ -49,6 +51,26 @@ export class ChallengeCardComponent implements OnInit {
 
   toggleFavorite (event: MouseEvent): void {
     event.stopPropagation()
+    // Verificamos si el usuario está logueado
+    if (!this.authService.isUserLoggedIn()) {
+      console.log('User not logged in. Favorite action is blocked.')
+      return // No hacemos nada si no está logueado
+    }
+    // Cambiamos visualmente de inmediato
     this.isFavorite = !this.isFavorite
+    this.favorites_count += this.isFavorite ? 1 : -1
+    // Llamamos al backend según el estado
+    if (this.isFavorite) {
+      this.challengeService.addToFavorites(this.id).subscribe({
+        next: response => {
+          console.log('Favorite added:', response)
+        },
+        error: error => {
+          console.error('Error adding favorite:', error)
+        }
+      })
+    } else {
+      console.log('Aquí llamaremos a removeFromFavorites más adelante.')
+    }
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -57,7 +57,6 @@ export class ChallengeCardComponent implements OnInit {
     if (this.isFavorite) {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
-          console.log('Favorite added:', response)
           this.isFavorite = response.isFavorite
           this.favorites_count = response.timesFavorited;
         },


### PR DESCRIPTION
**Related User Story** → This PR belongs to User Story 251 → Likes y bookmarks

**What has been done in this PR?** → 

- Removed the optimistic local flip of isFavorite and the debug console.log.

- Now waits for the backend response and then sets: this.isFavorite  = response.isFavorite;

**How to test it?** 

1. Initial load  → Log in as a user and you should see your favourites challenges marked.  (Without logging in, clicking the heart should do nothing)

2. Navigate to a challenge card or header: the heart icon should be filled/unfilled exactly as on the server, and the count should match timesFavorited.

3. Toggling a favorite

4. Click the heart button.

5. Verify in the Network tab that → A POST /challenge/challenges/{id}/favorites is sent.

Only after the 200 OK returns do the icon and count update.

If you force a 500 error, confirm the icon rolls back to “not favorite” and you see an error in the console.

**Notes**

- The “remove from favorites” branch remains unimplemented and will be addressed in a follow-up sprint.
