### PR TITLE
Feature/327 remove like backend

### DIFF
--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -222,14 +222,21 @@ describe('ChallengeService', () => {
       expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
       req.flush(mockResp)
     })
-    it('should catch error and return default fallback', (done) => {
-      service.removeFromFavorites(testId).subscribe((res) => {
-        expect(res).toEqual({ isFavorite: true, timesFavorited: 0 })
-        done()
+    it('should propagate error when remove fails', (done) => {
+      service.removeFromFavorites(testId).subscribe({
+        next: () => {
+          fail('Expected an error, but got a success response')
+        },
+        error: (err) => {
+          expect(err.status).toBe(500)
+          expect(err.statusText).toBe('Server Error')
+          done()
+        }
       })
       const req = httpMock.expectOne(
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
       )
+      expect(req.request.method).toBe('DELETE')
       req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' })
     })
   })

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -142,43 +142,6 @@ describe('ChallengeService', () => {
     httpMock.verify()
   })
 
-  // Tests for mocked favorites functionality
-  describe('removeFromFavorites (mock)', () => {
-    const testId = 'test-challenge-123'
-
-    beforeEach(() => {
-      localStorage.removeItem(`is_favorite_${testId}`)
-      localStorage.removeItem(`favorites_count_${testId}`)
-    })
-
-    it('should remove a challenge from favorites', fakeAsync(() => {
-      localStorage.setItem(`is_favorite_${testId}`, 'true')
-      localStorage.setItem(`favorites_count_${testId}`, '3')
-      let result: FavoriteResponse | undefined
-
-      service.removeFromFavorites(testId).subscribe((r) => {
-        result = r
-      })
-      tick(300)
-
-      expect(result).toEqual({ isFavorite: false, timesFavorited: 2 })
-      expect(localStorage.getItem(`is_favorite_${testId}`)).toBe('false')
-      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('2')
-    }))
-
-    it('should not decrement below zero when removing favorites', fakeAsync(() => {
-      localStorage.setItem(`is_favorite_${testId}`, 'true')
-      localStorage.setItem(`favorites_count_${testId}`, '0')
-      let result: FavoriteResponse | undefined
-      service.removeFromFavorites(testId).subscribe(r => {
-        result = r
-      })
-      tick(300)
-
-      expect(result).toEqual({ isFavorite: false, timesFavorited: 0 })
-      expect(localStorage.getItem(`favorites_count_${testId}`)).toBe('0')
-    }))
-  })
   describe('addToFavorites (real HTTP)', () => {
     const testId = 'test-challenge-123'
 
@@ -226,6 +189,48 @@ describe('ChallengeService', () => {
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
       )
       req.flush({ message: 'Server error' }, { status: 500, statusText: 'Error' })
+    })
+  })
+
+  describe('removeFromFavorites (real HTTP)', () => {
+    const testId = 'test-challenge-123'
+    beforeEach(() => {
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          provideHttpClient(withInterceptorsFromDi()),
+          provideHttpClientTesting(),
+          { provide: AuthService, useValue: authServiceStub }
+        ]
+      })
+      service = TestBed.inject(ChallengeService)
+      httpMock = TestBed.inject(HttpTestingController)
+    })
+    afterEach(() => {
+      httpMock.verify()
+    })
+    it('should DELETE and return backend response', (done) => {
+      const mockResp: FavoriteResponse = { isFavorite: false, timesFavorited: 41 }
+      service.removeFromFavorites(testId).subscribe((res) => {
+        expect(res).toEqual(mockResp)
+        done()
+      })
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      expect(req.request.method).toBe('DELETE')
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
+      req.flush(mockResp)
+    })
+    it('should catch error and return default fallback', (done) => {
+      service.removeFromFavorites(testId).subscribe((res) => {
+        expect(res).toEqual({ isFavorite: true, timesFavorited: 0 })
+        done()
+      })
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`
+      )
+      req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' })
     })
   })
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -122,7 +122,6 @@ export class ChallengeService {
     );
   }
 
-  // Mocked version for frontend testing
   removeFromFavorites (challengeId: string): Observable<FavoriteResponse> {
     const headers = {
       'Content-Type': 'application/json',

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -123,19 +123,21 @@ export class ChallengeService {
   }
 
   // Mocked version for frontend testing
-  removeFromFavorites(challengeId: string): Observable<FavoriteResponse> {
-
-    const currentCount = this.getMockFavoriteCount(challengeId);
-    
-    const mockResponse: FavoriteResponse = {
-      isFavorite: false,
-      timesFavorited: currentCount > 0 ? currentCount - 1 : 0
-    }
-    
-    localStorage.setItem(`is_favorite_${challengeId}`, 'false');
-    localStorage.setItem(`favorites_count_${challengeId}`, mockResponse.timesFavorited.toString());
-    
-    return of(mockResponse).pipe(delay(300));
+  removeFromFavorites (challengeId: string): Observable<FavoriteResponse> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    return this.http.delete<FavoriteResponse>(url, { headers }).pipe(
+      map(response => {
+        return response;
+      }),
+      catchError(error => {
+        console.error('Error removing from favorites:', error);
+        return of({ isFavorite: true, timesFavorited: 0 });
+      })
+    );
   }
 
   // Helper methods for mock implementation

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -127,7 +127,7 @@ export class ChallengeService {
       'Content-Type': 'application/json',
       ...this.authService.getAuthHeaders()
     };
-    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}/${challengeId}/favorites`;
     return this.http.delete<FavoriteResponse>(url, { headers }).pipe(
       map(response => {
         return response;

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable padded-blocks */
 /* eslint-disable @typescript-eslint/semi */
 import { Inject, Injectable, inject } from '@angular/core'
-import { Observable, catchError, BehaviorSubject, of } from 'rxjs'
+import { Observable, catchError, BehaviorSubject, of, throwError } from 'rxjs'
 import { delay, map } from 'rxjs/operators'
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http'
 import { type Itinerary } from '../models/itinerary.interface'
@@ -134,7 +134,7 @@ export class ChallengeService {
       }),
       catchError(error => {
         console.error('Error removing from favorites:', error);
-        return of({ isFavorite: true, timesFavorited: 0 });
+        return throwError(() => error);
       })
     );
   }


### PR DESCRIPTION
This PR implements the logic to **remove a challenge from a user's favorites by making a DELETE request to the backend.**

The `removeFromFavorites(challengeId: string)` method has been updated in `ChallengeService` to:

- Replace the mock implementation using localStorage.
- Call the real backend endpoint: DELETE /challenge/challenges/{challengeId}/favorites.
- Include the required authentication headers (Bearer token).
- Return the response as an Observable of type `FavoriteResponse`.

Functionality has been tested manually and returns expected backend data.

**This task corresponds to user story 314 and completes task 327.**