### PR TITLE
Fix/269 adjust mentor view spacing

### DIFF
--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -8,13 +8,16 @@
   height: 1rem;
 
   .languageSelect {
-    font-size: 0.75rem;
+    font-size: 1rem;
     border: none;
     border-radius: 0.625rem;
     font-weight: 450;
     background-color: $white;
     color: $gray-6;
     height: 38px;
+    padding: 0 0.5rem;
+    min-width: fit-content;
+    width: auto;
     transition: transform 0.3s ease 0s;
 
     &:focus-visible {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -34,7 +34,7 @@
     transition: transform 0.3s ease 0s;
     min-width: 7rem;
     padding: 0 12px;
-    margin-right: -1rem;
+    margin-right: 0rem;
 
 
     &:disabled {

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -7,7 +7,7 @@
 
   <!-- CHALLENGES -->
   <div id="challenges-container" class="col-12 col-xl-8">
-    <div class="challenges-filter  actions-container">
+    <div class="challenges-filter">
       <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
         <h2>{{ "modules.starter.main.section2.title" | translate }}</h2>
         <div class="d-flex gap-2 align-items-center">

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -7,18 +7,17 @@
 
   <!-- CHALLENGES -->
   <div id="challenges-container" class="col-12 col-xl-8">
-    <div class="challenges-filter">
-      <div class="d-flex justify-content-between align-items-center">
+    <div class="challenges-filter  actions-container">
+      <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
         <h2>{{ "modules.starter.main.section2.title" | translate }}</h2>
-        <button [routerLink]="['/ita-challenge/challenges/new-challenge']" *ngIf="isAdmin" class="btn btn-sm btn-primary new-challenge-btn">
-          {{ "components.mainMenu.section4.title" | translate }}
-        </button>
-      </div>
-      
-      <div class="d-flex justify-content-end d-xl-none mb-2">
-        <button class="btn btn-outline-primary btnFiltrar" (click)="openModal()">
-          <strong>Filtrar</strong>
-        </button>
+        <div class="d-flex gap-2 align-items-center">
+          <button class="btn btn-outline-primary btnFiltrar d-xl-none" (click)="openModal()">
+            <strong>Filtrar</strong>
+          </button>
+          <button [routerLink]="['/ita-challenge/challenges/new-challenge']" *ngIf="isAdmin" class="btn btn-sm btn-primary new-challenge-btn">
+            {{ "components.mainMenu.section4.title" | translate }}
+          </button>
+        </div>
       </div>
     </div>
 
@@ -50,4 +49,4 @@
     </app-pagination>
   </div>
 </div>
- <app-filters-modal #modal  (filtersSelected)="getChallengeFilters($event)"></app-filters-modal> 
+ <app-filters-modal #modal  (filtersSelected)="getChallengeFilters($event)"></app-filters-modal>

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -45,7 +45,7 @@
     </div>
 
     <!-- PAGINATION -->
-    <app-pagination class="d-none d-xl-block"  (pageEmitter)="getChallengesByPage($event)" [totalPages]="totalPages" [pageNumber]="pageNumber">
+    <app-pagination (pageEmitter)="getChallengesByPage($event)" [totalPages]="totalPages" [pageNumber]="pageNumber">
     </app-pagination>
   </div>
 </div>

--- a/src/app/modules/starter/components/starter/starter.component.scss
+++ b/src/app/modules/starter/components/starter/starter.component.scss
@@ -4,6 +4,7 @@
 
 .starter {
   height: 100%;
+  margin-top: 1rem;
 }
 
 h2 {
@@ -80,7 +81,7 @@ app-starter-filters p {
 .challenges-filter{
    
    h2 {
-     margin-bottom: 0;
+     margin-bottom: 1.5rem;
    }
 }
 #filters-container {
@@ -117,34 +118,4 @@ app-pagination {
   height: 2.8rem;
   padding-left: 1.3rem !important;
   padding-right: 1.3rem !important;
-}
-
-
-.starter {
-  margin-top: 1rem;
-  .challenges-filter {
-    margin-bottom: 1.5rem;
-
-    .d-flex {
-      @media (max-width: 1200px) {
-        flex-wrap: wrap;
-        gap: 1rem;
-      }
-
-      h2 {
-        margin-bottom: 0;
-      }
-    }
-
-    .new-challenge-btn {
-      white-space: nowrap;
-      min-width: fit-content;
-    }
-
-    .btnFiltrar {
-      @media (min-width: 1200px) {
-        display: none;
-      }
-    }
-  }
 }

--- a/src/app/modules/starter/components/starter/starter.component.scss
+++ b/src/app/modules/starter/components/starter/starter.component.scss
@@ -118,3 +118,33 @@ app-pagination {
   padding-left: 1.3rem !important;
   padding-right: 1.3rem !important;
 }
+
+
+.starter {
+  margin-top: 1rem;
+  .challenges-filter {
+    margin-bottom: 1.5rem;
+
+    .d-flex {
+      @media (max-width: 1200px) {
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+
+      h2 {
+        margin-bottom: 0;
+      }
+    }
+
+    .new-challenge-btn {
+      white-space: nowrap;
+      min-width: fit-content;
+    }
+
+    .btnFiltrar {
+      @media (min-width: 1200px) {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR addresses several spacing and layout issues in the mentor view across different screen sizes:

### Changes Made
1. Login Button Spacing
   
   - Before: Button had incorrect right margin
   ![Captura de pantalla 2025-05-05 a las 9 54 58](https://github.com/user-attachments/assets/6c0b6233-1bbc-425d-a4db-a895bcccd3b8)
   - After: Adjusted right margin for better alignment
     ![Captura de pantalla 2025-05-07 a las 10 35 00](https://github.com/user-attachments/assets/5cfa3fda-aa17-4333-99dc-465d1996275b)


2. Create Challenge & Filter Buttons
   - Before: Inconsistent spacing on medium and large screens
![Captura de pantalla 2025-05-05 a las 10 39 54](https://github.com/user-attachments/assets/5bc0d467-2522-45dc-a0d0-962133c78e4f)

   - After: Improved button spacing and alignment
![Captura de pantalla 2025-05-07 a las 10 41 53](https://github.com/user-attachments/assets/87d609f2-41dd-4952-a74d-75d931354050)


3. Pagination Visibility
   
   - Before: Pagination was hidden on some screen sizes
   - After: Maintained pagination visibility across all screen sizes, ensuring users can access and navigate through all challenges regardless of device size
![Captura de pantalla 2025-05-07 a las 11 13 39](https://github.com/user-attachments/assets/f0abb818-326b-4fbd-aaf5-5b2370a16f5b)

4. Language Selector Adjustment

- Before: Language selector text size and container width were inconsistent
![Captura de pantalla 2025-05-07 a las 11 36 29](https://github.com/user-attachments/assets/8e5e74a7-aaf2-4f26-b671-20b3930c2821)

- After: Optimized text size and implemented auto-width container that adapts to content
![Captura de pantalla 2025-05-07 a las 11 36 09](https://github.com/user-attachments/assets/fc17f4c6-c2d4-4736-924b-d2a3ebdf93b5)

### Related
Sprint 6: task 269
    