### PR TITLE
Feature/328 update favorite UI

### DIFF
--- a/src/app/models/favorite-response.interface.ts
+++ b/src/app/models/favorite-response.interface.ts
@@ -1,4 +1,4 @@
 export interface FavoriteResponse {
-  isFavorite: boolean
+  favorite: boolean
   timesFavorited: number
 }

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -188,22 +188,6 @@ export class ChallengeHeaderComponent implements OnInit {
     }
   }
 
-  private addToFavorites(): void {
-    this.challengeService.addToFavorites(this.idChallenge).subscribe(response => {
-      this.isFavorite = response.isFavorite
-      this.favorites_count = response.timesFavorited
-      this.favoritesUpdated.emit(this.favorites_count)
-    })
-  }
-
-  private removeFromFavorites(): void {
-    this.challengeService.removeFromFavorites(this.idChallenge).subscribe(response => {
-      this.isFavorite = response.isFavorite
-      this.favorites_count = response.timesFavorited
-      this.favoritesUpdated.emit(this.favorites_count)
-    })
-  }
-
   private checkFavoriteStatus(): void {
     const isFavorited = localStorage.getItem(`is_favorite_${this.idChallenge}`);
     this.isFavorite = isFavorited === 'true';

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -164,7 +164,7 @@ export class ChallengeHeaderComponent implements OnInit {
     if (this.isFavorite) {
       this.challengeService.removeFromFavorites(this.idChallenge).subscribe({
         next: response => {
-          this.isFavorite = response.isFavorite
+          this.isFavorite = false
           this.favorites_count = response.timesFavorited
           console.log('Favorite removed:', response)
           this.favoritesUpdated.emit(this.favorites_count)
@@ -176,7 +176,7 @@ export class ChallengeHeaderComponent implements OnInit {
     } else {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
         next: response => {
-          this.isFavorite = response.isFavorite
+          this.isFavorite = true
           this.favorites_count = response.timesFavorited
           console.log('Favorite added:', response)
           this.favoritesUpdated.emit(this.favorites_count)

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -164,7 +164,6 @@ export class ChallengeHeaderComponent implements OnInit {
         next: response => {
           this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
-          console.log('Favorite removed:', response)
           this.favoritesUpdated.emit(this.favorites_count)
         },
         error: error => {
@@ -176,7 +175,6 @@ export class ChallengeHeaderComponent implements OnInit {
         next: response => {
           this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
-          console.log('Favorite added:', response)
           this.favoritesUpdated.emit(this.favorites_count)
         },
         error: error => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -60,8 +60,6 @@ export class ChallengeHeaderComponent implements OnInit {
     const savedSolutions = JSON.parse(localStorage.getItem('solutions') ?? '[]') as string[]
     this.solutionSent = savedSolutions.includes(this.idChallenge)
 
-    this.checkFavoriteStatus()
-
     this.solutionService.challengeCompleted$.subscribe({
       next: (challengeId: string) => {
         if (challengeId === this.idChallenge) {
@@ -185,17 +183,6 @@ export class ChallengeHeaderComponent implements OnInit {
           console.error('Error adding favorite:', error)
         }
       })
-    }
-  }
-
-  private checkFavoriteStatus(): void {
-    const isFavorited = localStorage.getItem(`is_favorite_${this.idChallenge}`);
-    this.isFavorite = isFavorited === 'true';
-    
-    const storedCount = localStorage.getItem(`favorites_count_${this.idChallenge}`);
-    if (storedCount) {
-      this.favorites_count = parseInt(storedCount, 10);
-      this.favoritesUpdated.emit(this.favorites_count);
     }
   }
 }

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -162,7 +162,7 @@ export class ChallengeHeaderComponent implements OnInit {
     if (this.isFavorite) {
       this.challengeService.removeFromFavorites(this.idChallenge).subscribe({
         next: response => {
-          this.isFavorite = false
+          this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
           console.log('Favorite removed:', response)
           this.favoritesUpdated.emit(this.favorites_count)
@@ -174,7 +174,7 @@ export class ChallengeHeaderComponent implements OnInit {
     } else {
       this.challengeService.addToFavorites(this.idChallenge).subscribe({
         next: response => {
-          this.isFavorite = true
+          this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
           console.log('Favorite added:', response)
           this.favoritesUpdated.emit(this.favorites_count)

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -161,17 +161,30 @@ export class ChallengeHeaderComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
-    this.isFavorite = !this.isFavorite
-    this.favorites_count += this.isFavorite ? 1 : -1
     if (this.isFavorite) {
-      this.challengeService.addToFavorites(this.idChallenge).subscribe({
-        next: () => {
+      this.challengeService.removeFromFavorites(this.idChallenge).subscribe({
+        next: response => {
+          this.isFavorite = response.isFavorite
+          this.favorites_count = response.timesFavorited
+          console.log('Favorite removed:', response)
+          this.favoritesUpdated.emit(this.favorites_count)
         },
-        error: () => {
+        error: error => {
+          console.error('Error removing favorite:', error)
         }
       })
     } else {
-    // TODO: Implementar removeFromFavorites en la PR correspondiente
+      this.challengeService.addToFavorites(this.idChallenge).subscribe({
+        next: response => {
+          this.isFavorite = response.isFavorite
+          this.favorites_count = response.timesFavorited
+          console.log('Favorite added:', response)
+          this.favoritesUpdated.emit(this.favorites_count)
+        },
+        error: error => {
+          console.error('Error adding favorite:', error)
+        }
+      })
     }
   }
 

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -163,7 +163,7 @@ describe('ChallengeService', () => {
     })
 
     it('should POST and return backend response', (done) => {
-      const mockResp: FavoriteResponse = { isFavorite: true, timesFavorited: 42 }
+      const mockResp: FavoriteResponse = { favorite: true, timesFavorited: 42 }
 
       service.addToFavorites(testId).subscribe((res) => {
         expect(res).toEqual(mockResp)
@@ -181,7 +181,7 @@ describe('ChallengeService', () => {
 
     it('should catch error and return default', (done) => {
       service.addToFavorites(testId).subscribe((res) => {
-        expect(res).toEqual({ isFavorite: false, timesFavorited: 0 })
+        expect(res).toEqual({ favorite: false, timesFavorited: 0 })
         done()
       })
 
@@ -210,7 +210,7 @@ describe('ChallengeService', () => {
       httpMock.verify()
     })
     it('should DELETE and return backend response', (done) => {
-      const mockResp: FavoriteResponse = { isFavorite: false, timesFavorited: 41 }
+      const mockResp: FavoriteResponse = { favorite: false, timesFavorited: 41 }
       service.removeFromFavorites(testId).subscribe((res) => {
         expect(res).toEqual(mockResp)
         done()
@@ -222,6 +222,7 @@ describe('ChallengeService', () => {
       expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
       req.flush(mockResp)
     })
+<<<<<<< HEAD
     it('should propagate error when remove fails', (done) => {
       service.removeFromFavorites(testId).subscribe({
         next: () => {
@@ -232,6 +233,12 @@ describe('ChallengeService', () => {
           expect(err.statusText).toBe('Server Error')
           done()
         }
+=======
+    it('should catch error and return default fallback', (done) => {
+      service.removeFromFavorites(testId).subscribe((res) => {
+        expect(res).toEqual({ favorite: true, timesFavorited: 0 })
+        done()
+>>>>>>> e78bff48 (test: update mock responses to match updated FavoriteRespons interface)
       })
       const req = httpMock.expectOne(
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -222,7 +222,7 @@ describe('ChallengeService', () => {
       expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
       req.flush(mockResp)
     })
-<<<<<<< HEAD
+
     it('should propagate error when remove fails', (done) => {
       service.removeFromFavorites(testId).subscribe({
         next: () => {
@@ -233,12 +233,6 @@ describe('ChallengeService', () => {
           expect(err.statusText).toBe('Server Error')
           done()
         }
-=======
-    it('should catch error and return default fallback', (done) => {
-      service.removeFromFavorites(testId).subscribe((res) => {
-        expect(res).toEqual({ favorite: true, timesFavorited: 0 })
-        done()
->>>>>>> e78bff48 (test: update mock responses to match updated FavoriteRespons interface)
       })
       const req = httpMock.expectOne(
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${testId}/favorites`

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -117,7 +117,7 @@ export class ChallengeService {
       }),
       catchError(error => {
         console.error('Error adding to favorites:', error);
-        return of({ isFavorite: false, timesFavorited: 0 });
+        return of({ favorite: false, timesFavorited: 0 });
       })
     );
   }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -67,7 +67,16 @@ export class ChallengeCardComponent implements OnInit {
         }
       })
     } else {
-    // TODO: Implement removeFromFavorites functionality
+      this.challengeService.removeFromFavorites(this.id).subscribe({
+        next: response => {
+          this.isFavorite = response.isFavorite
+          this.favorites_count = response.timesFavorited
+          console.log('Favorite removed:', response)
+        },
+        error: error => {
+          console.error('Error removing favorite:', error)
+        }
+      })
     }
   }
 }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -10,7 +10,7 @@ import { AuthService } from 'src/app/services/auth.service'
   styleUrls: ['./challenge-card.component.scss'],
   providers: []
 })
-export class ChallengeCardComponent implements OnInit {
+export class ChallengeCardComponent {
   private readonly starterService = inject(StarterService)
   private readonly translate = inject(TranslateService)
   private readonly challengeService = inject(ChallengeService)
@@ -25,28 +25,8 @@ export class ChallengeCardComponent implements OnInit {
   @Input() favorites_count: number = 0
   isFavorite: boolean = false;
 
-  ngOnInit(): void {
-    // Check if challenge is favorited in localStorage
-    this.checkFavoriteStatus();
-  }
-
   get currentLang (): string {
     return this.translate.currentLang
-  }
-
-  // Check if the challenge is in favorites
-  private checkFavoriteStatus(): void {
-    if (!this.id) return;
-    
-    // For mock purposes, we'll check localStorage
-    const isFavorited = localStorage.getItem(`is_favorite_${this.id}`);
-    this.isFavorite = isFavorited === 'true';
-    
-    // Also update the favorites count from localStorage if available
-    const storedCount = localStorage.getItem(`favorites_count_${this.id}`);
-    if (storedCount) {
-      this.favorites_count = parseInt(storedCount, 10);
-    }
   }
 
   toggleFavorite (event: MouseEvent): void {
@@ -57,7 +37,7 @@ export class ChallengeCardComponent implements OnInit {
     if (this.isFavorite) {
       this.challengeService.removeFromFavorites(this.id).subscribe({
         next: response => {
-          this.isFavorite = response.isFavorite
+          this.isFavorite = false
           this.favorites_count = response.timesFavorited
           console.log('Favorite removed:', response)
         },
@@ -68,7 +48,7 @@ export class ChallengeCardComponent implements OnInit {
     } else {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
-          this.isFavorite = response.isFavorite
+          this.isFavorite = true
           this.favorites_count = response.timesFavorited
           console.log('Favorite added:', response)
         },

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -54,19 +54,8 @@ export class ChallengeCardComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
-    this.isFavorite = !this.isFavorite
-    this.favorites_count = this.isFavorite ? this.favorites_count + 1 : Math.max(0, this.favorites_count - 1)
     // Llamamos al backend según el estado
     if (this.isFavorite) {
-      this.challengeService.addToFavorites(this.id).subscribe({
-        next: response => {
-          console.log('Favorite added:', response)
-        },
-        error: error => {
-          console.error('Error adding favorite:', error)
-        }
-      })
-    } else {
       this.challengeService.removeFromFavorites(this.id).subscribe({
         next: response => {
           this.isFavorite = response.isFavorite
@@ -75,6 +64,17 @@ export class ChallengeCardComponent implements OnInit {
         },
         error: error => {
           console.error('Error removing favorite:', error)
+        }
+      })
+    } else {
+      this.challengeService.addToFavorites(this.id).subscribe({
+        next: response => {
+          this.isFavorite = response.isFavorite
+          this.favorites_count = response.timesFavorited
+          console.log('Favorite added:', response)
+        },
+        error: error => {
+          console.error('Error adding favorite:', error)
         }
       })
     }

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -37,7 +37,7 @@ export class ChallengeCardComponent {
     if (this.isFavorite) {
       this.challengeService.removeFromFavorites(this.id).subscribe({
         next: response => {
-          this.isFavorite = false
+          this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
           console.log('Favorite removed:', response)
         },
@@ -48,7 +48,7 @@ export class ChallengeCardComponent {
     } else {
       this.challengeService.addToFavorites(this.id).subscribe({
         next: response => {
-          this.isFavorite = true
+          this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
           console.log('Favorite added:', response)
         },

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -54,7 +54,6 @@ export class ChallengeCardComponent implements OnInit {
     if (!this.authService.isUserLoggedIn()) {
       return
     }
-    // Llamamos al backend según el estado
     if (this.isFavorite) {
       this.challengeService.removeFromFavorites(this.id).subscribe({
         next: response => {


### PR DESCRIPTION
This PR completes task 328, **part of user story 314** - "As a mentor, I can give/remove likes and see my liked challenges".

**Functional changes:**

- Updated the `toggleFavorite()` method in both `ChallengeCardComponent` and `ChallengeHeaderComponent` to call real backend endpoints.
- Removed local optimistic updates (`isFavorite`, `favorites_count`) in favor of backend response.
- Connected both `addToFavorites` and `removeFromFavorites` directly from `ChallengeService`.
- Deleted unused internal methods in `ChallengeHeaderComponent` that previously handled favorite logic.

 **How to Test It**

1. Log in as a mentor.
2. Go to the challenge list and click the heart icon (toggle favorite).
3. Verify:
   - When liking a challenge: a POST request is made to the backend.
   - When unliking: a DELETE request is made.
   - The heart icon updates correctly (filled/empty).
   - The favorites counter updates based on the backend response.

4. Navigate to the challenge detail page:
   - Use the heart icon in the header.
   - Verify the same behavior (add/remove favorites) works as expected.