### PR TITLE
Feature/330 show likes count

### DIFF
--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -10,6 +10,7 @@ export class Challenge {
   popularity: number
   favorites_count: number
   saved_count: number
+  timesFavorite: number
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []
@@ -22,6 +23,7 @@ export class Challenge {
     this.popularity = element.popularity
     this.favorites_count = element.favorites_count || 0
     this.saved_count = element.saved_count || 0
+    this.timesFavorite = element.timesFavorite || 0
     this.detail = element.detail
 
     element.languages.forEach((language: Language) => {

--- a/src/app/modules/challenge/components/challenge/challenge.component.html
+++ b/src/app/modules/challenge/components/challenge/challenge.component.html
@@ -5,7 +5,7 @@
         [level]="level"
         [activeId]="activeId"
         [idChallenge]="idChallenge"
-        [favorites_count]="challenge ? challenge.favorites_count || 0 : 0"
+        [favorites_count]="challenge.timesFavorite || 0"
         (startChallenge)="onStartChallenge($event)"
         (favoritesUpdated)="onFavoritesUpdated($event)"
 >   </app-challenge-header>

--- a/src/app/modules/challenge/components/challenge/challenge.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.spec.ts
@@ -17,6 +17,10 @@ import { SolutionComponent } from '../../../../shared/components/solution/soluti
 import { DynamicTranslatePipe } from 'src/app/pipes/dynamic-translate.pipe'
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { CookieService } from 'ngx-cookie-service'
+import { registerLocaleData } from '@angular/common'
+import localeCa from '@angular/common/locales/ca'
+
+registerLocaleData(localeCa)
 
 describe('ChallengeComponent', () => {
   let component: ChallengeComponent
@@ -27,7 +31,20 @@ describe('ChallengeComponent', () => {
   beforeEach(async () => {
     mockChallengeService = {
       getChallengeById: jasmine.createSpy('getChallengeById').and.returnValue(of({
-        solutions: []
+        challenge_title: '',
+        creation_date: new Date(),
+        level: '',
+        detail: {
+          description: '',
+          examples: [],
+          notes: ''
+        },
+        related: [],
+        resources: [],
+        solutions: [],
+        popularity: 0,
+        languages: [],
+        timesFavorite: 0
       }))
     }
 
@@ -109,7 +126,8 @@ describe('ChallengeComponent', () => {
       resources: [],
       solutions: [],
       popularity: 0,
-      languages: []
+      languages: [],
+      timesFavorite: 0
     }
 
     mockChallengeService.getChallengeById.and.returnValue(of(challenge))
@@ -133,7 +151,8 @@ describe('ChallengeComponent', () => {
       resources: [],
       solutions: [],
       popularity: 0,
-      languages: []
+      languages: [],
+      timesFavorite: 0
     }
 
     mockChallengeService.getChallengeById.and.returnValue(of(challenge))
@@ -183,7 +202,8 @@ describe('ChallengeComponent', () => {
       resources: [],
       solutions: [],
       popularity: 0,
-      languages: []
+      languages: [],
+      timesFavorite: 0
     }
 
     mockChallengeService.getChallengeById.and.returnValue(of(challenge))

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -41,7 +41,7 @@
         [title]="challenge.challenge_title  | dynamicTranslate" [creation_date]="challenge.creation_date"
         [level]="challenge.level" [popularity]="challenge.popularity" [languages]="challenge.languages"
         [id]="challenge.id_challenge" 
-        [favorites_count]="challenge.favorites_count || 0">
+        [favorites_count]="challenge.timesFavorite || 0">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -40,7 +40,8 @@
       <app-challenge-card *ngFor="let challenge of challenges, let i = index"
         [title]="challenge.challenge_title  | dynamicTranslate" [creation_date]="challenge.creation_date"
         [level]="challenge.level" [popularity]="challenge.popularity" [languages]="challenge.languages"
-        [id]="challenge.id_challenge" [favorites_count]="challenge.favorites_count || 0">
+        [id]="challenge.id_challenge" 
+        [favorites_count]="challenge.favorites_count || 0">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.spec.ts
+++ b/src/app/modules/starter/components/starter/starter.component.spec.ts
@@ -20,6 +20,7 @@ describe('StarterComponent', () => {
   const mockChallenges$: Challenge[] = mockChallenges.map((challenge: any) => ({
     ...challenge,
     creation_date: new Date(`${challenge.creation_date}`),
+    timesFavorite: typeof challenge.timesFavorite === 'number' ? challenge.timesFavorite : 0,
     solutions: challenge.solutions.map((solution: any) => ({
       id_solution: solution.idSolution,
       solution_text: solution.solutionText

--- a/src/app/services/starter.service.spec.ts
+++ b/src/app/services/starter.service.spec.ts
@@ -35,8 +35,9 @@ describe('StarterService', () => {
         id_solution: solution.idSolution,
         solution_text: solution.solutionText
       })),
-      favorites_count: 0, 
-      saved_count: 0 
+      favorites_count: 0,
+      saved_count: 0,
+      timesFavorite: 0
     }))
   })
 


### PR DESCRIPTION
**This PR completes task 330, part of user story 314 – "As a mentor, I can give/remove likes and see my liked challenges."**

**Functional changes:** -> show the real like count from the backend – always up to date.

**How to Test It**

1. Log in
2. Navigate to the challenge list view
3. Each card should display a heart icon with the number of likes (based on timesFavorite from backend).
4. Go to the challenge detail page:
5. Confirm that the heart icon in the header also reflects the accurate like count.

