### PR TITLE
feature/357 progress filter ui

### DIFF
--- a/src/app/modules/starter/components/starter-filters/starter-filters.component.html
+++ b/src/app/modules/starter/components/starter-filters/starter-filters.component.html
@@ -35,7 +35,7 @@
     </div>
   </div>
   
-  <div class="form" formGroupName="progress">
+  <div class="form" formGroupName="progress" *ngIf="isUserLoggedIn">
     <p class="mb-2"><span>{{'modules.starter.filters.progress' | translate}}</span></p>
     <div class="form-check">
       <input class="form-check-input" type="checkbox" id="checkNoStarted" formControlName="noStarted">

--- a/src/app/modules/starter/components/starter-filters/starter-filters.component.html
+++ b/src/app/modules/starter/components/starter-filters/starter-filters.component.html
@@ -35,7 +35,7 @@
     </div>
   </div>
   
-  <div class="form" formGroupName="progress" *ngIf="isUserLoggedIn">
+  <div class="form" formGroupName="progress">
     <p class="mb-2"><span>{{'modules.starter.filters.progress' | translate}}</span></p>
     <div class="form-check">
       <input class="form-check-input" type="checkbox" id="checkNoStarted" formControlName="noStarted">

--- a/src/app/modules/starter/components/starter-filters/starter-filters.component.spec.ts
+++ b/src/app/modules/starter/components/starter-filters/starter-filters.component.spec.ts
@@ -84,15 +84,15 @@ describe('StarterFiltersComponent', () => {
       expect(progressSection).toBeTruthy()
     })
     
-    it('should hide progress filters when user role is ADMIN', () => {
+    it('should display progress filters when user role is ADMIN', () => {
       authServiceMock.getUserRole.mockReturnValue(of('ADMIN'))
       
       component.ngOnInit()
       fixture.detectChanges()
       
-      expect(component.isUserLoggedIn).toBe(false)
+      expect(component.isUserLoggedIn).toBe(true)
       const progressSection = fixture.debugElement.query(By.css('[formGroupName="progress"]'))
-      expect(progressSection).toBeFalsy()
+      expect(progressSection).toBeTruthy()
     })
     
     it('should hide progress filters when user is not logged in (empty role)', () => {

--- a/src/app/modules/starter/components/starter-filters/starter-filters.component.ts
+++ b/src/app/modules/starter/components/starter-filters/starter-filters.component.ts
@@ -87,7 +87,7 @@ export class StarterFiltersComponent implements OnInit, OnDestroy {
     this.userRoleSubs$ = this.authService.getUserRole().subscribe({
       next: (role) => {
         // Enable user-specific filters only for authenticated non-admin users
-        this.isUserLoggedIn = role !== '' && role !== 'ADMIN'
+        this.isUserLoggedIn = role !== '' 
       },
       error: (error) => {
         console.error('Error getting user role:', error)


### PR DESCRIPTION
This PR completes task 357, part of user story 312 - "As a mentor, I can filter the challenges”.

The goal of this PR is to allow users with the ADMIN role to view and use the "Progress" section within the challenge filters, which was previously restricted.

**Functional changes:**

Updated the logic that controls visibility of the Progress filter section:

- Previously, it was hidden for users with the ADMIN role.
- Now, it is visible and fully functional for both authenticated users and admins.
- Updated unit tests to reflect this role-based behavior, ensuring ADMIN users also trigger the expected UI rendering.