### PR TITLE
Feature/329 show favorite on login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ### [ita-challenges-frontend-3.1.34-RELEASE] (2025-05-14) (feature#375)
 
 - Cleanup pagination logic
+
+### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
+
+- Mentors can like/unlike challenges and view their liked challenges and see number of likes on each challenge. 
 
 ### [ita-challenges-frontend-3.1.33-RELEASE] (2025-04-10) (fix#261)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,9 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-### [ita-challenges-frontend-3.1.34-RELEASE] (2025-05-14) (feature#375)
+### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 
 - Cleanup pagination logic
-
-### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 
 - Mentors can like/unlike challenges and view their liked challenges and see number of likes on each challenge. 
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -36,6 +36,7 @@ export class ChallengeHeaderComponent implements OnInit {
   @Input() idChallenge!: string
   @Input() isEditorChallengeVisible: boolean = false
   @Input() favorites_count: number = 0
+  @Input() isFavorite: boolean = false
 
   @Output() startChallenge = new EventEmitter<boolean>()
   @Output() favoritesUpdated = new EventEmitter<number>()
@@ -46,7 +47,6 @@ export class ChallengeHeaderComponent implements OnInit {
 
   challengeStarted: boolean = false
   solutionSent: boolean = false
-  isFavorite: boolean = false
 
   ngOnInit (): void {
     this.challenge_title = this.title

--- a/src/app/modules/challenge/components/challenge/challenge.component.html
+++ b/src/app/modules/challenge/components/challenge/challenge.component.html
@@ -8,6 +8,8 @@
         [favorites_count]="challenge.timesFavorite || 0"
         (startChallenge)="onStartChallenge($event)"
         (favoritesUpdated)="onFavoritesUpdated($event)"
+        [isFavorite]="isFavoriteChallenge(challenge.id_challenge)"
+
 >   </app-challenge-header>
 
     <app-challenge-info

--- a/src/app/modules/challenge/components/challenge/challenge.component.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.ts
@@ -63,7 +63,6 @@ export class ChallengeComponent implements OnInit, OnDestroy {
         if (userId !== null && userId !== '') {
           this.challengeService.getUserFavorites(userId).subscribe({
             next: (favorites: any[]) => {
-              console.log('User favorites from backend:', favorites)
               this.favoriteChallenges = favorites
             },
             error: (err) => {

--- a/src/app/modules/challenge/components/challenge/challenge.component.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.ts
@@ -9,6 +9,7 @@ import { type Resource } from 'src/app/models/resource.model'
 import { type Example } from 'src/app/models/challenge-example.model'
 import { type Language } from 'src/app/models/language.model'
 import { ChallengeTab } from 'src/app/shared/enums/challenge-tab.enum'
+import { AuthService } from 'src/app/services/auth.service'
 
 @Component({
   selector: 'app-challenge',
@@ -39,10 +40,12 @@ export class ChallengeComponent implements OnInit, OnDestroy {
   isEditorChallengeVisible = false
   startChallenge: boolean = false
   challengeStarted: boolean = false
+  favoriteChallenges: string[] = []
 
   private readonly route = inject(ActivatedRoute)
   private readonly router = inject(Router)
   private readonly challengeService = inject(ChallengeService)
+  private readonly _authService = inject(AuthService)
 
   ngOnInit (): void {
     this.params$ = this.route.paramMap.subscribe((params: ParamMap) => {
@@ -55,6 +58,26 @@ export class ChallengeComponent implements OnInit, OnDestroy {
       const url = this.router.url // Obtiene la URL actual
       this.isEditorChallengeVisible = url.includes('/start') // Verifica si contiene "/start"
     })
+    if (this._authService.isUserLoggedIn()) {
+      this._authService.getUserId().subscribe(userId => {
+        if (userId !== null && userId !== '') {
+          this.challengeService.getUserFavorites(userId).subscribe({
+            next: (favorites: any[]) => {
+              console.log('User favorites from backend:', favorites)
+              this.favoriteChallenges = favorites
+            },
+            error: (err) => {
+              console.error('Error getting favorites:', err)
+            }
+          })
+        }
+      })
+    }
+  }
+
+  isFavoriteChallenge (challengeId: string): boolean {
+    const result = this.favoriteChallenges.includes(challengeId)
+    return result
   }
 
   onStartChallenge (started: boolean): void {

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -42,7 +42,7 @@
         [level]="challenge.level" [popularity]="challenge.popularity" [languages]="challenge.languages"
         [id]="challenge.id_challenge" 
         [favorites_count]="challenge.timesFavorite || 0"
-        [isUserFavorite]="isFavoriteChallenge(challenge.id_challenge)">
+        [isFavorite]="isFavoriteChallenge(challenge.id_challenge)">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -41,7 +41,8 @@
         [title]="challenge.challenge_title  | dynamicTranslate" [creation_date]="challenge.creation_date"
         [level]="challenge.level" [popularity]="challenge.popularity" [languages]="challenge.languages"
         [id]="challenge.id_challenge" 
-        [favorites_count]="challenge.timesFavorite || 0">
+        [favorites_count]="challenge.timesFavorite || 0"
+        [isUserFavorite]="isFavoriteChallenge(challenge.id_challenge)">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.spec.ts
+++ b/src/app/modules/starter/components/starter/starter.component.spec.ts
@@ -32,7 +32,9 @@ describe('StarterComponent', () => {
     authRoleSubject = new BehaviorSubject<string>('')
     const authServiceMock = {
       getUserRole: () => authRoleSubject.asObservable(),
-      updateUserRoleAndUserNameFromToken: () => {}
+      updateUserRoleAndUserNameFromToken: () => {},
+      isUserLoggedIn: () => true,
+      getUserId: () => of('mock-user-id')
     }
 
     TestBed.configureTestingModule({

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -7,6 +7,7 @@ import { type FiltersModalComponent } from 'src/app/modules/modals/filters-modal
 import { TranslateService } from '@ngx-translate/core'
 import { AuthService } from 'src/app/services/auth.service'
 import * as bootstrap from 'bootstrap'
+import { ChallengeService } from 'src/app/services/challenge.service'
 
 @Component({
   selector: 'app-starter',
@@ -34,12 +35,15 @@ export class StarterComponent implements OnInit {
   isAscending: boolean = false
 
   isMobile: boolean = window.innerWidth < 768
+
   isAdmin: boolean = false
+  favoriteChallenges: string[] = []
 
   constructor (
     @Inject(StarterService) private readonly starterService: StarterService,
     @Inject(TranslateService) readonly translate: TranslateService,
-    private _authService: AuthService
+    private readonly _authService: AuthService,
+    private readonly challengeService: ChallengeService
   ) {}
 
   ngOnInit (): void {
@@ -47,6 +51,21 @@ export class StarterComponent implements OnInit {
     this.userRoleSubs$ = this._authService.getUserRole().subscribe(role => {
       this.isAdmin = role === 'ADMIN'
     })
+    if (this._authService.isUserLoggedIn()) {
+      this._authService.getUserId().subscribe(userId => {
+        if (userId !== null && userId !== '') {
+          this.challengeService.getUserFavorites(userId).subscribe({
+            next: (favorites: any[]) => {
+              console.log('User favorites from backend:', favorites)
+              this.favoriteChallenges = favorites
+            },
+            error: (err) => {
+              console.error('Error getting favorites:', err)
+            }
+          })
+        }
+      })
+    }
   }
 
   ngOnDestroy (): void {
@@ -54,6 +73,11 @@ export class StarterComponent implements OnInit {
     if (this.filteredChallengesSubs$ !== undefined) this.filteredChallengesSubs$.unsubscribe()
     if (this.sortedChallengesSubs$ !== undefined) this.sortedChallengesSubs$.unsubscribe()
     if (this.userRoleSubs$ !== undefined) this.userRoleSubs$.unsubscribe()
+  }
+
+  isFavoriteChallenge (challengeId: string): boolean {
+    const result = this.favoriteChallenges.includes(challengeId)
+    return result
   }
 
   getChallenge (): void {

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -56,7 +56,6 @@ export class StarterComponent implements OnInit {
         if (userId !== null && userId !== '') {
           this.challengeService.getUserFavorites(userId).subscribe({
             next: (favorites: any[]) => {
-              console.log('User favorites from backend:', favorites)
               this.favoriteChallenges = favorites
             },
             error: (err) => {

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -133,7 +133,6 @@ export class ChallengeService {
         return response;
       }),
       catchError(error => {
-        console.error('Error removing from favorites:', error);
         return throwError(() => error);
       })
     );

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -106,6 +106,7 @@ export class ChallengeService {
       'Content-Type': 'application/json',
       ...this.authService.getAuthHeaders()
     };
+    // TODO: change URL once the backend is ready
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
     return this.http.post<FavoriteResponse>(
       url,
@@ -127,6 +128,7 @@ export class ChallengeService {
       'Content-Type': 'application/json',
       ...this.authService.getAuthHeaders()
     };
+    // TODO: change URL once the backend is ready
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}/${challengeId}/favorites`;
     return this.http.delete<FavoriteResponse>(url, { headers }).pipe(
       map(response => {

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -139,6 +139,15 @@ export class ChallengeService {
     );
   }
 
+  getUserFavorites (userId: string): Observable<string[]> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_USER_FAVORITES}/${userId}/favorites`;
+    return this.http.get<string[]>(url, { headers });
+  }
+
   // Helper methods for mock implementation
   private getMockFavoriteCount(challengeId: string): number {
     const key = `favorites_count_${challengeId}`

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -23,7 +23,7 @@ export class ChallengeCardComponent {
   @Input() popularity!: number
   @Input() id = ''
   @Input() favorites_count: number = 0
-  isFavorite: boolean = false;
+  @Input() isFavorite: boolean = false
 
   get currentLang (): string {
     return this.translate.currentLang

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -39,7 +39,6 @@ export class ChallengeCardComponent {
         next: response => {
           this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
-          console.log('Favorite removed:', response)
         },
         error: error => {
           console.error('Error removing favorite:', error)
@@ -50,7 +49,6 @@ export class ChallengeCardComponent {
         next: response => {
           this.isFavorite = response.favorite
           this.favorites_count = response.timesFavorited
-          console.log('Favorite added:', response)
         },
         error: error => {
           console.error('Error adding favorite:', error)

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -6,6 +6,7 @@ export const environment = {
   BACKEND_ITA_CHALLENGE_BASE_URL: '/itachallenge/api/v1',
   BACKEND_ITA_CHALLENGE_SOLUTION: '/challenge/solution',
   BACKEND_ITA_CHALLENGE_USER_SOLUTION: '/user/solution',
+  BACKEND_USER_FAVORITES: '/user/users',
   BACKEND_ITA_CHALLENGE_TAGS: '/challenge/tags',
   BACKEND_ITA_SSO_BASE_URL: 'https://dev.sso.itawiki.eurecatacademy.org/api/v1',
   BACKEND_ITA_WIKI_BASE_URL: 'https://dev.itawiki.eurecatacademy.org/api/v1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,6 +6,7 @@ export const environment = {
   BACKEND_ITA_CHALLENGE_BASE_URL: '/itachallenge/api/v1',
   BACKEND_ITA_CHALLENGE_SOLUTION: '/challenge/solution',
   BACKEND_ITA_CHALLENGE_USER_SOLUTION: '/user/solution',
+  BACKEND_USER_FAVORITES: '/user/users',
   BACKEND_ITA_CHALLENGE_TAGS: '/challenge/tags',
   BACKEND_ITA_SSO_BASE_URL: 'https://dev.sso.itawiki.eurecatacademy.org/api/v1',
   BACKEND_ITA_WIKI_BASE_URL: 'https://dev.itawiki.eurecatacademy.org/api/v1',


### PR DESCRIPTION
This PR completes task 329, part of user story 314 – "As a mentor, I can give/remove likes and see my liked challenges."

**Functional changes:**

- When a user logs in, their list of liked challenges is fetched from the backend.

- On the challenge list page, the heart icon is automatically filled for challenges the user has already liked.

- On the challenge detail page, the heart icon in the header is also filled for liked challenges.

**How to Test It:**

1. Log in with a user that has liked some challenges.

2. Navigate to the challenge list view:

3. Confirm that liked challenges show a filled heart icon.

4. Click on any liked challenge to go to the detail view:

5. The header should also display a filled heart icon.

![image](https://github.com/user-attachments/assets/b7259f0c-334a-4f2d-8a48-0e7f66ead465)
![image](https://github.com/user-attachments/assets/39b1b1d4-0fc1-4a37-ad4d-b3bf3a4d5537)
