### PR TITLE
Feature/335 style order filters_v02

### DIFF
--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -22,7 +22,7 @@
     </div>
 
     <!-- SORT BY -->
-    <ul id="sortBy" class="d-xl-flex justify-content-end gap-2 d-none">
+    <ul id="sortBy" class="d-xl-flex justify-content-end d-none">
       <li class="animated"
         [ngClass]="{'selected' : sortBy == 'popularity', 'up': sortBy === 'popularity' && !isAscending}"
         (click)="changeSort('popularity')">

--- a/src/app/modules/starter/components/starter/starter.component.scss
+++ b/src/app/modules/starter/components/starter/starter.component.scss
@@ -17,6 +17,10 @@ img[alt='filter-icon'] {
   cursor: pointer;
 }
 
+#sortBy{
+  gap: 30px;
+}
+
 ul {
   list-style: none;
   
@@ -26,7 +30,7 @@ ul {
     line-height: 16px;
     font-weight: 500;
     color: $gray-3;
-    gap: 2px;
+    gap: 5px;
     cursor: pointer;
 
     &::after {


### PR DESCRIPTION
This PR completes task **335**, part of user story 313 - "General layout review for mentor screens".

Updated the order filter style to reflect the client's wireframe design.

Files changed: starter.component.css and html

Before:
![image](https://github.com/user-attachments/assets/00f6e54a-8ce2-4287-be97-42e7d9febcc4)

After:
![image](https://github.com/user-attachments/assets/367b571b-34ef-42f0-aa39-0701c5d01447)
