### PR TITLE
refactor/381 new favorite endpoints

### DIFF
--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -116,7 +116,7 @@ describe('ChallengeService', () => {
       name: 'favorites',
       addFn: 'addToFavorites',
       removeFn: 'removeFromFavorites',
-      pathBase: `${environment.BACKEND_ALL_CHALLENGES_URL}/`,
+      pathBase: `${environment.BACKEND_ITA_FAVORITES}/`,
       successAdd: { favorite: true, timesFavorited: 42 },
       successRemove: { favorite: false, timesFavorited: 41 },
       errorStrategy: 'default',

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -13,6 +13,7 @@ const authServiceStub = {
 describe('ChallengeService', () => {
   let service: ChallengeService
   let httpMock: HttpTestingController
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -29,8 +30,7 @@ describe('ChallengeService', () => {
     TestBed.resetTestingModule()
   })
 
-  // Helper para endpoints POST/DELETE
-  function expectEndpoint (
+  function expectEndpoint(
     path: string,
     method: 'POST' | 'DELETE',
     response: object,
@@ -85,7 +85,15 @@ describe('ChallengeService', () => {
   })
 
   it('should create challenge and return response', (done) => {
-    const mockChallenge: CreateChallenge = { challengeTitle: 'T', description: 'D', level: 'EASY', language: 'Java', solution: 'S', topic: 'ALL', tags: [] }
+    const mockChallenge: CreateChallenge = {
+      challengeTitle: 'T',
+      description: 'D',
+      level: 'EASY',
+      language: 'Java',
+      solution: 'S',
+      topic: 'ALL',
+      tags: []
+    }
     const mockResp = { id: 1, ...mockChallenge }
     service.createChallenge(mockChallenge).subscribe(res => {
       expect(res).toEqual(mockResp)
@@ -99,7 +107,6 @@ describe('ChallengeService', () => {
     req.flush(mockResp)
   })
 
-  // Parametrized tests for Favorites and Bookmarks
   interface ApiCase {
     name: string
     addFn: keyof ChallengeService
@@ -136,14 +143,18 @@ describe('ChallengeService', () => {
   apiCases.forEach(c => {
     describe(c.name, () => {
       const id = 'test-id'
-      const path = `${c.pathBase}${id}/${c.name}`
+
+      const buildPath = () =>
+        c.name === 'favorites'
+          ? `${c.pathBase}${id}`
+          : `${c.pathBase}${id}/${c.name}`
 
       it(`should add ${c.name}`, done => {
         (service[c.addFn] as any)(id).subscribe({
           next: (res: any) => { expect(res).toEqual(c.successAdd); done() },
           error: (err: any) => done.fail(`Unexpected error: ${err}`)
         })
-        expectEndpoint(path, 'POST', c.successAdd)
+        expectEndpoint(buildPath(), 'POST', c.successAdd)
       })
 
       it(`should remove ${c.name}`, done => {
@@ -151,7 +162,7 @@ describe('ChallengeService', () => {
           next: (res: any) => { expect(res).toEqual(c.successRemove); done() },
           error: (err: any) => done.fail(`Unexpected error: ${err}`)
         })
-        expectEndpoint(path, 'DELETE', c.successRemove)
+        expectEndpoint(buildPath(), 'DELETE', c.successRemove)
       })
 
       it(`should handle error on add ${c.name}`, done => {
@@ -173,7 +184,7 @@ describe('ChallengeService', () => {
             }
           }
         })
-        expectEndpoint(path, 'POST', { message: 'Err' }, 500, 'Err')
+        expectEndpoint(buildPath(), 'POST', { message: 'Err' }, 500, 'Err')
       })
 
       it(`should propagate error on remove ${c.name}`, done => {
@@ -181,7 +192,7 @@ describe('ChallengeService', () => {
           next: () => done.fail('Expected error'),
           error: (err: any) => { expect(err.status).toBe(500); done() }
         })
-        expectEndpoint(path, 'DELETE', { message: 'Err' }, 500, 'Err')
+        expectEndpoint(buildPath(), 'DELETE', { message: 'Err' }, 500, 'Err')
       })
     })
   })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -106,8 +106,7 @@ export class ChallengeService {
       'Content-Type': 'application/json',
       ...this.authService.getAuthHeaders()
     };
-    // TODO: change URL once the backend is ready
-    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${challengeId}/favorites`;
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_FAVORITES}/${challengeId}`;
     return this.http.post<FavoriteResponse>(
       url,
       {},
@@ -128,8 +127,7 @@ export class ChallengeService {
       'Content-Type': 'application/json',
       ...this.authService.getAuthHeaders()
     };
-    // TODO: change URL once the backend is ready
-    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}/${challengeId}/favorites`;
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_FAVORITES}/${challengeId}`;
     return this.http.delete<FavoriteResponse>(url, { headers }).pipe(
       map(response => {
         return response;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -13,6 +13,7 @@ export const environment = {
   BACKEND_ITA_WIKI_RESOURCES: '/resources',
   BACKEND_ITA_WIKI_CATEGORIES: '/categories',
   BACKEND_ALL_CHALLENGES_URL: '/challenge/challenges',
+  BACKEND_ITA_FAVORITES: '/favorite/challenges',
   BACKEND_ALL_LANGUAGE_URL: '/languages/',
   BACKEND_SSO_ITINERARIES: '/itineraries',
   BACKEND_SSO_LOGIN_URL: '/auth/login',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,6 +13,7 @@ export const environment = {
   BACKEND_ITA_WIKI_RESOURCES: '/resources',
   BACKEND_ITA_WIKI_CATEGORIES: '/categories',
   BACKEND_ALL_CHALLENGES_URL: '/challenge/challenges',
+  BACKEND_ITA_FAVORITES: '/favorite/challenges',
   BACKEND_ALL_LANGUAGE_URL: '/languages/',
   BACKEND_SSO_ITINERARIES: '/itineraries',
   BACKEND_SSO_LOGIN_URL: '/auth/login',


### PR DESCRIPTION
This PR 381 takes part of the user story 325 - "Modularidad de ChallengeController"

This change proposes adding a new endpoint to the environment files, corresponding to the FavoriteController in the backend.

It also involves modifying the HTTP calls in challenge.service (see PR #606) to correctly point to the updated URLs.

You can find the new endpoints documented in the Wiki:
![image](https://github.com/user-attachments/assets/6f91fcc8-d747-4f53-8b05-16e398105ad9)
