### PR TITLE
PR 1/4 - feat(user):  show current role with a toggle (#400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 
 - "Popularidad" filter logic
 
+- Toggle Switch role
+
 ### [ita-challenges-frontend-3.1.33-RELEASE] (2025-04-10) (fix#261)
 
 - Remove examples and notes sections from challenge info component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 - Toggle Switch role
 
+
+### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
+
 - Cleanup pagination logic
 
 - Mentors can like/unlike challenges and view their liked challenges and see number of likes on each challenge. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 
+- Toggle Switch role
+
 - Cleanup pagination logic
 
 - Mentors can like/unlike challenges and view their liked challenges and see number of likes on each challenge. 
@@ -13,8 +15,6 @@ and this project adheres to
 - "Volver a retos" link added
 
 - "Popularidad" filter logic
-
-- Toggle Switch role
 
 ### [ita-challenges-frontend-3.1.33-RELEASE] (2025-04-10) (fix#261)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
+### [ita-challenges-frontend-3.1.35-RELEASE] - 2025-05-28
 
 - Toggle Switch role
 

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -11,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core'
 import { MobileNavComponent } from './layout/header/mobile-nav/mobile-nav.component'
 import { DesktopNavComponent } from './layout/header/desktop-nav/desktop-nav.component'
 import { MentorLoginComponent } from '../modules/mentor/mentor-login/mentor-login.component'
+import { SharedComponentsModule } from '../shared/components/shared-components.module'
 
 @NgModule({
   declarations: [
@@ -32,7 +33,8 @@ import { MentorLoginComponent } from '../modules/mentor/mentor-login/mentor-logi
     ModalsModule,
     I18nModule,
     TranslateModule,
-    MentorLoginComponent
+    MentorLoginComponent,
+    SharedComponentsModule
   ]
 })
 export class CoreModule { }

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -19,11 +19,7 @@
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>
           <a>
-            <div class="form-check form-switch d-flex gap-2 justify-content-evenly align-items-center">
-              <span>{{ roles[1] }}</span>
-              <input class="form-check-input" type="checkbox" role="switch" id="switchCheckRole" [checked]="currentRole === roles[0]"/>
-              <span>{{ roles[0] }}</span>
-            </div>
+            <app-toggle [currentRole]="currentRole"></app-toggle>
           </a>
           <a (click)="logout()">{{'modules.challenge.header.logout' | translate}}<img src="assets/img/icon/logout.svg" alt="logout" style="height: 17px;"></a>
       </div>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -18,6 +18,13 @@
       </button>
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>
+          <a>
+            <div class="form-check form-switch d-flex gap-2 justify-content-evenly align-items-center">
+              <span>{{ roles[1] }}</span>
+              <input class="form-check-input" type="checkbox" role="switch" id="switchCheckRole" [checked]="currentRole === roles[0]"/>
+              <span>{{ roles[0] }}</span>
+            </div>
+          </a>
           <a (click)="logout()">{{'modules.challenge.header.logout' | translate}}<img src="assets/img/icon/logout.svg" alt="logout" style="height: 17px;"></a>
       </div>
     </div>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -109,7 +109,6 @@
     left: -8.75rem;
     border-radius: 10px;
     margin-top: 0.4rem;
-    // width: 178px;
     border: 1px solid #ccc;
     font-size: 14px;
   }

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -136,28 +136,6 @@
   }
   
 }
-.form-switch{
-  padding-left: 0px;
-}
-.form-check-input[type=checkbox]:not(:checked) {
-  background-color: #ddd;
-  border-color: #ccc;
-}
-.form-check .form-check-input {
-  margin-left: 0px;
-}
-.form-check-input {
-  height: 24px;
-  width: 44px;
-  background-color: $primary;
-  border-color: $primary;
-}
-
-.form-check-input:checked {
-  background-color: $primary;
-  border-color: $primary;
-}
-
 @media screen and (max-width: 768px) {
   .desktop-nav {
     display: none;

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -106,11 +106,10 @@
     min-width: 160px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     z-index: 1;
-    left: -6.75rem;
+    left: -8.75rem;
     border-radius: 10px;
     margin-top: 0.4rem;
-    height: 92px;
-    width: 168px;
+    // width: 178px;
     border: 1px solid #ccc;
     font-size: 14px;
   }
@@ -136,6 +135,27 @@
     border-bottom: 1px solid #ccc;
   }
   
+}
+.form-switch{
+  padding-left: 0px;
+}
+.form-check-input[type=checkbox]:not(:checked) {
+  background-color: #ddd;
+  border-color: #ccc;
+}
+.form-check .form-check-input {
+  margin-left: 0px;
+}
+.form-check-input {
+  height: 24px;
+  width: 44px;
+  background-color: $primary;
+  border-color: $primary;
+}
+
+.form-check-input:checked {
+  background-color: $primary;
+  border-color: $primary;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.spec.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.spec.ts
@@ -19,6 +19,9 @@ class MockAuthService {
   getUsername = jest.fn(() => of('test-user'));
   isLoggedIn$ = of(true); 
   logout = jest.fn();
+  getUserRole() {
+    return of('')
+  }
 }
 
 const mockActivatedRoute = {
@@ -125,6 +128,12 @@ describe('DesktopNavComponent', () => {
     component.ngOnInit(); 
     expect(component.user).toBe('');
   });
+
+  it('should set currentRole to empty string if AuthService returns empty', () => {
+    jest.spyOn(authService, 'getUserRole').mockReturnValue(of(''))
+    component.ngOnInit()
+    expect(component.currentRole).toBe('')
+  })
 
   it('should call logout method from AuthService when logout is triggered', () => {
     const logoutSpy = jest.spyOn(authService, 'logout');

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -2,6 +2,7 @@ import { Component, HostListener, Inject, OnDestroy, OnInit } from '@angular/cor
 import { from, Subscription } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { NavService } from 'src/app/services/nav.service'; 
+import { ToggleComponent } from 'src/app/shared/components/toggle/toggle.component';
 
 @Component({
   selector: 'app-desktop-nav',
@@ -13,10 +14,8 @@ export class DesktopNavComponent implements OnInit, OnDestroy {
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';
-  currentRole: string = ''
   private authSubscription!: Subscription;
-  roles: string[] = ['ADMIN', 'alumno']
-  selectedRole: string = ''
+  currentRole: string = ''
 
 
   constructor(

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, Inject, OnDestroy, OnInit } from '@angular/core';
-import { from, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { NavService } from 'src/app/services/nav.service'; 
 import { ToggleComponent } from 'src/app/shared/components/toggle/toggle.component';
@@ -10,7 +10,7 @@ import { ToggleComponent } from 'src/app/shared/components/toggle/toggle.compone
   styleUrl: './desktop-nav.component.scss'
 })
 
-export class DesktopNavComponent implements OnInit, OnDestroy {
+export class DesktopNavComponent implements OnInit, OnDestroy{
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -1,7 +1,7 @@
 import { Component, HostListener, Inject, OnDestroy, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { from, Subscription } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
-import { NavService } from 'src/app/services/nav.service';
+import { NavService } from 'src/app/services/nav.service'; 
 
 @Component({
   selector: 'app-desktop-nav',
@@ -9,11 +9,14 @@ import { NavService } from 'src/app/services/nav.service';
   styleUrl: './desktop-nav.component.scss'
 })
 
-export class DesktopNavComponent implements OnInit, OnDestroy{
+export class DesktopNavComponent implements OnInit, OnDestroy {
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';
+  currentRole: string = ''
   private authSubscription!: Subscription;
+  roles: string[] = ['ADMIN', 'alumno']
+  selectedRole: string = ''
 
 
   constructor(
@@ -30,6 +33,9 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
     });
+    this._authService.getUserRole().subscribe((userRole) => {
+      this.currentRole = userRole
+    })
   }
 
     ngOnDestroy(): void {

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
@@ -29,6 +29,9 @@
           </button>
           <div class="dropdown-mobile" [ngClass]="{ 'show': dropdownOpen }">
               <a>{{user}}</a>
+              <a>
+                <app-toggle [currentRole]="currentRole"></app-toggle>
+              </a>
               <a (click)="logout()">{{'modules.challenge.header.logout' | translate}}<img src="assets/img/icon/logout.svg" alt="logout" style="height: 17px;"></a>
           </div>
         </div>

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
@@ -112,18 +112,16 @@ $navbar-toggler-transition: none;
   
     .dropdown-mobile {
       display: none;
-      position: absolute;
-      background-color: white;
-      min-width: 160px;
-      box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-      z-index: 1;
-      left: -6.75rem;
-      border-radius: 10px;
-      margin-top: 0.4rem;
-      height: 92px;
-      width: 168px;
-      border: 1px solid #ccc;
-      font-size: 14px;
+        position: absolute;
+        background-color: white;
+        min-width: 160px;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        z-index: 1;
+        left: -8.75rem;
+        border-radius: 10px;
+        margin-top: 0.4rem;
+        border: 1px solid #ccc;
+        font-size: 14px;
     }
     .dropdown-mobile.show {
       display: flex;

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.spec.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.spec.ts
@@ -19,6 +19,9 @@ class MockAuthService {
   getUsername = jest.fn(() => of('test-user'));
   isLoggedIn$ = of(true); 
   logout = jest.fn();
+  getUserRole() {
+    return of('')
+  }
 }
 
 const mockActivatedRoute = {

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
@@ -12,6 +12,7 @@ export class MobileNavComponent implements OnInit, OnDestroy{
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';
+  currentRole: string = ''
   private authSubscription!: Subscription;
 
 
@@ -29,6 +30,10 @@ export class MobileNavComponent implements OnInit, OnDestroy{
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
     });
+
+    this._authService.getUserRole().subscribe((userRole) => {
+      this.currentRole = userRole
+    })
   }
 
     ngOnDestroy(): void {

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -10,7 +10,7 @@ import { TranslateModule } from '@ngx-translate/core'
 import { DynamicTranslatePipe } from 'src/app/pipes/dynamic-translate.pipe'
 import { EscapeJavaForJsonPipe } from '../../pipes/escape-java-chars.pipe'
 import { FormsModule } from '@angular/forms'
-import { EditorModule } from '@tinymce/tinymce-angular';
+import { EditorModule } from '@tinymce/tinymce-angular'
 import { ToggleComponent } from './toggle/toggle.component'
 
 @NgModule({

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -10,14 +10,16 @@ import { TranslateModule } from '@ngx-translate/core'
 import { DynamicTranslatePipe } from 'src/app/pipes/dynamic-translate.pipe'
 import { EscapeJavaForJsonPipe } from '../../pipes/escape-java-chars.pipe'
 import { FormsModule } from '@angular/forms'
-import { EditorModule } from '@tinymce/tinymce-angular'
+import { EditorModule } from '@tinymce/tinymce-angular';
+import { ToggleComponent } from './toggle/toggle.component'
 
 @NgModule({
   declarations: [
     ChallengeCardComponent,
     ResourceCardComponent,
     SolutionComponent,
-    BreadcrumbComponent
+    BreadcrumbComponent,
+    ToggleComponent
   ],
   imports: [
     CommonModule,
@@ -35,7 +37,8 @@ import { EditorModule } from '@tinymce/tinymce-angular'
     SolutionComponent,
     BreadcrumbComponent,
     DynamicTranslatePipe,
-    EscapeJavaForJsonPipe
+    EscapeJavaForJsonPipe,
+    ToggleComponent
   ]
 })
 export class SharedComponentsModule { }

--- a/src/app/shared/components/toggle/toggle.component.cy.ts
+++ b/src/app/shared/components/toggle/toggle.component.cy.ts
@@ -1,0 +1,7 @@
+import { ToggleComponent } from './toggle.component'
+
+describe('ToggleComponent', () => {
+  it('should mount', () => {
+    cy.mount(ToggleComponent)
+  })
+})

--- a/src/app/shared/components/toggle/toggle.component.html
+++ b/src/app/shared/components/toggle/toggle.component.html
@@ -1,0 +1,6 @@
+<div class="form-check form-switch d-flex gap-2 justify-content-evenly align-items-center">
+    <span>{{ roles[1] }}</span>
+    <input class="form-check-input" type="checkbox" role="switch" id="switchCheckRole"
+        [checked]="currentRole === roles[0]" />
+    <span>{{ roles[0] }}</span>
+</div>

--- a/src/app/shared/components/toggle/toggle.component.scss
+++ b/src/app/shared/components/toggle/toggle.component.scss
@@ -1,0 +1,23 @@
+@import "/src/styles/colors";
+
+.form-switch{
+  padding-left: 0px;
+}
+.form-check-input[type=checkbox]:not(:checked) {
+  background-color: #ddd;
+  border-color: #ccc;
+}
+.form-check .form-check-input {
+  margin-left: 0px;
+}
+.form-check-input {
+  height: 24px;
+  width: 44px;
+  background-color: $primary;
+  border-color: $primary;
+}
+
+.form-check-input:checked {
+  background-color: $primary;
+  border-color: $primary;
+}

--- a/src/app/shared/components/toggle/toggle.component.ts
+++ b/src/app/shared/components/toggle/toggle.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core'
 @Component({
   selector: 'app-toggle',
   templateUrl: './toggle.component.html',
-  styleUrl: './toggle.component.css'
+  styleUrl: './toggle.component.scss'
 })
 export class ToggleComponent {
   @Input() currentRole: string = ''

--- a/src/app/shared/components/toggle/toggle.component.ts
+++ b/src/app/shared/components/toggle/toggle.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core'
+
+@Component({
+  selector: 'app-toggle',
+  templateUrl: './toggle.component.html',
+  styleUrl: './toggle.component.css'
+})
+export class ToggleComponent {
+  @Input() currentRole: string = ''
+  roles: string[] = ['ADMIN', 'alumno']
+  selectedRole: string = ''
+}

--- a/src/app/shared/components/toggle/toggle.component.ts
+++ b/src/app/shared/components/toggle/toggle.component.ts
@@ -7,6 +7,6 @@ import { Component, Input } from '@angular/core'
 })
 export class ToggleComponent {
   @Input() currentRole: string = ''
-  roles: string[] = ['ADMIN', 'alumno']
+  roles: string[] = ['ADMIN', 'USER']
   selectedRole: string = ''
 }


### PR DESCRIPTION
### Description
This PR completes task **400**, part of user story 388 - "As a user, I can see my role and be able to modify it in the profile drop-down menu.". This PR is a feature branch based on develop that serves as the base for other sub-branches related to a backend task.

Created a new toggle component that indicates the role of the logged-in user. This component is used in the Header component.

### How to test:
- Sign in with Github
- Click the menu button and check if there is display a toggle switch with your current role selected.

### Before and after comparison:
Before:
![image](https://github.com/user-attachments/assets/607a1ca1-ed5c-4b4a-bca8-6ed2f95764e7)

After:
![image](https://github.com/user-attachments/assets/d7b044ec-ff6b-402a-8892-ca584de010e7)


### Files changed:

- shared-components.module.ts
- toggle component
- header component
- core.module.ts

### Auto self-check:

- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x] Title, description, and changelog (if needed) are filled in correctly
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [ ] All automated checks (like SonarCloud) have passed
- [x] I responded to all previous review comments and only resolved those I truly addressed