### PR TITLE
feat(user): assign profile users photo (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - Show user solution (mock) alongside mentor solution in completed challenges (#424)
 - load user solution from endpoint instead of mock (#423)
 - adjust solution.component.css to match Figma design (#425)
+- Added user's photo (#433)
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -20,7 +20,7 @@
       }
       @else {
         <button class="user userWithPhoto" (click)="toggleDropdown()">
-          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto" aria-label="User menu">
+          <img [src]="userPhoto" alt="User" class="img-fluid" aria-label="User menu">
         </button>
       }
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -14,7 +14,7 @@
   @if(isLoggedIn){
     <div class="user-container">
       <button [ngClass]="{'user':true, 'userWithPhoto':!userPhoto}" (click)="toggleDropdown()">
-        <img src="userPhoto ? userPhoto : assets/img/icon/user.svg" alt="User" [ngClass]="{'img-fluid': !userPhoto}">
+        <img src="userPhoto ? userPhoto : assets/img/icon/user.svg" [alt]="'components.header.userPhoto' | translate" [ngClass]="{'img-fluid': !userPhoto}">
       </button>
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -13,16 +13,6 @@
   <!-- Login -->
   @if(isLoggedIn){
     <div class="user-container">
-       <!-- @if (!userPhoto) {
-        <button class="user" (click)="toggleDropdown()">
-          <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
-        </button>
-      }
-      @else {
-        <button class="user userWithPhoto" (click)="toggleDropdown()">
-          <img [src]="userPhoto" alt="User" class="img-fluid" aria-label="User menu">
-        </button>
-      } -->
       <button [ngClass]="{'user':true, 'userWithPhoto':!userPhoto}" (click)="toggleDropdown()">
         <img src="userPhoto ? userPhoto : assets/img/icon/user.svg" alt="User" [ngClass]="{'img-fluid': !userPhoto}">
       </button>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -20,7 +20,7 @@
       }
       @else {
         <button class="user userWithPhoto" (click)="toggleDropdown()">
-          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
+          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto" aria-label="User menu">
         </button>
       }
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -13,9 +13,16 @@
   <!-- Login -->
   @if(isLoggedIn){
     <div class="user-container">
-      <button class="user" (click)="toggleDropdown()">
-        <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
-      </button>
+       @if (!userPhoto) {
+        <button class="user" (click)="toggleDropdown()">
+          <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
+        </button>
+      }
+      @else {
+        <button class="userWithPhoto" (click)="toggleDropdown()">
+          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto" style="border: none; padding: 0; background: none;">
+        </button>
+      }
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>
           <a>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -20,7 +20,7 @@
       }
       @else {
         <button class="userWithPhoto" (click)="toggleDropdown()">
-          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto" style="border: none; padding: 0; background: none;">
+          <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
         </button>
       }
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -13,8 +13,8 @@
   <!-- Login -->
   @if(isLoggedIn){
     <div class="user-container">
-      <button [ngClass]="{'user':true, 'userWithPhoto':!userPhoto}" (click)="toggleDropdown()">
-        <img src="userPhoto ? userPhoto : assets/img/icon/user.svg" [alt]="'components.header.userPhoto' | translate" [ngClass]="{'img-fluid': !userPhoto}">
+      <button [ngClass]="{'user':true, 'userWithPhoto':userPhoto !=''}" (click)="toggleDropdown()">
+        <img [src]="userPhoto ? userPhoto : 'assets/img/icon/user.svg'" [alt]="'components.header.userPhoto' | translate" [ngClass]="{'img-fluid': userPhoto !=''}">
       </button>
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -13,7 +13,7 @@
   <!-- Login -->
   @if(isLoggedIn){
     <div class="user-container">
-       @if (!userPhoto) {
+       <!-- @if (!userPhoto) {
         <button class="user" (click)="toggleDropdown()">
           <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
         </button>
@@ -22,7 +22,10 @@
         <button class="user userWithPhoto" (click)="toggleDropdown()">
           <img [src]="userPhoto" alt="User" class="img-fluid" aria-label="User menu">
         </button>
-      }
+      } -->
+      <button [ngClass]="{'user':true, 'userWithPhoto':!userPhoto}" (click)="toggleDropdown()">
+        <img src="userPhoto ? userPhoto : assets/img/icon/user.svg" alt="User" [ngClass]="{'img-fluid': !userPhoto}">
+      </button>
       <div class="dropdown" [ngClass]="{ 'show': dropdownOpen }">
           <a>{{user}}</a>
           <a>

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.html
@@ -19,7 +19,7 @@
         </button>
       }
       @else {
-        <button class="userWithPhoto" (click)="toggleDropdown()">
+        <button class="user userWithPhoto" (click)="toggleDropdown()">
           <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
         </button>
       }

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -89,14 +89,25 @@
 
   .user {
     border: unset;
-    width: 48px;
-    height: 41px;
     background: $white;
     border-radius: 10px;
     width: 45px;
     height: 38px;
     position: relative;
     display: inline-block;
+  }
+
+  .userWithPhoto {
+    border-radius: 50%;
+    border: unset;
+    width: 50px;
+    height: 50px;
+    position: relative;
+    display: inline-block;
+  }
+
+  .profilePhoto{
+    border-radius: 50px;
   }
 
   .dropdown {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -87,30 +87,6 @@
   display: inline-block;
 }
 
-  .user {
-    border: unset;
-    background: $white;
-    border-radius: 10px;
-    width: 45px;
-    height: 38px;
-    position: relative;
-    display: inline-block;
-  }
-
-   .userWithPhoto {
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    position: relative;
-    display: inline-block;
-    padding: 0;
-    overflow: hidden;
-   }
-
-  .profilePhoto{
-    border-radius: 50px;
-  }
-
   .dropdown {
     display: none;
     position: absolute;

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.scss
@@ -97,14 +97,15 @@
     display: inline-block;
   }
 
-  .userWithPhoto {
+   .userWithPhoto {
     border-radius: 50%;
-    border: unset;
-    width: 50px;
-    height: 50px;
+    width: 40px;
+    height: 40px;
     position: relative;
     display: inline-block;
-  }
+    padding: 0;
+    overflow: hidden;
+   }
 
   .profilePhoto{
     border-radius: 50px;

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.spec.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.spec.ts
@@ -23,6 +23,8 @@ class MockAuthService {
     return of('')
   };
 
+  getUserPhoto = jest.fn(() => of('https://mock-photo-url.com/avatar.png'))
+
   checkAndHandleExpiredToken = jest.fn()
 }
 

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -2,7 +2,6 @@ import { Component, HostListener, Inject, OnDestroy, OnInit } from '@angular/cor
 import { Subscription } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
 import { NavService } from 'src/app/services/nav.service'; 
-import { ToggleComponent } from 'src/app/shared/components/toggle/toggle.component';
 
 @Component({
   selector: 'app-desktop-nav',

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -14,6 +14,7 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';
+  userPhoto: string = 'error'
   private authSubscription!: Subscription;
   currentRole: string = ''
   newRole: 'ADMIN' | 'USER' = 'ADMIN'
@@ -33,10 +34,17 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
     });
+<<<<<<< HEAD
     this._authService.getUserRole().subscribe((userRole) => {
       this.currentRole = userRole
     }) 
     this._authService.checkAndHandleExpiredToken()
+=======
+
+    this._authService.getUserPhoto().subscribe((userPhoto) => {
+      this.userPhoto = userPhoto
+    })
+>>>>>>> 3478adb1 (user's profile photo in desktop-nav)
   }
 
     ngOnDestroy(): void {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -29,7 +29,11 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
     this.authSubscription = this._authService.isLoggedIn$.subscribe(isLoggedIn => {
       this.isLoggedIn = isLoggedIn;
     });
+    this.loadUserBasicData()
+    this._authService.checkAndHandleExpiredToken()
+  }
 
+  loadUserBasicData():void{
     this._authService.updateUserRoleAndUserNameFromToken();
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
@@ -37,7 +41,9 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
     this._authService.getUserRole().subscribe((userRole) => {
       this.currentRole = userRole
     }) 
-    this._authService.checkAndHandleExpiredToken()
+    this._authService.getUserPhoto().subscribe((userPhoto) => {
+      this.userPhoto = userPhoto
+    })
   }
 
     ngOnDestroy(): void {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -34,17 +34,10 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
     });
-<<<<<<< HEAD
     this._authService.getUserRole().subscribe((userRole) => {
       this.currentRole = userRole
     }) 
     this._authService.checkAndHandleExpiredToken()
-=======
-
-    this._authService.getUserPhoto().subscribe((userPhoto) => {
-      this.userPhoto = userPhoto
-    })
->>>>>>> 3478adb1 (user's profile photo in desktop-nav)
   }
 
     ngOnDestroy(): void {

--- a/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
+++ b/src/app/core/layout/header/desktop-nav/desktop-nav.component.ts
@@ -14,7 +14,7 @@ export class DesktopNavComponent implements OnInit, OnDestroy{
   isLoggedIn = false;
   dropdownOpen: boolean = false;
   user: string = '';
-  userPhoto: string = 'error'
+  userPhoto: string = ''
   private authSubscription!: Subscription;
   currentRole: string = ''
   newRole: 'ADMIN' | 'USER' = 'ADMIN'

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
@@ -24,20 +24,13 @@
       <!-- Login -->
       @if(isLoggedIn){
         <div class="user-container-mobile">
-          @if (!userPhoto) {
-            <button class="user-mobile" (click)="toggleDropdown()">
-              <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
-            </button>
-          }
-          @else {
-            <button class="user-mobile userWithPhoto" (click)="toggleDropdown()">
-              <img [src]="userPhoto" alt="User" class="img-fluid">
-            </button>
-          }
+          <button [ngClass]="{'user-mobile':true, 'userWithPhoto':userPhoto !=''}" (click)="toggleDropdown()">
+            <img [src]="userPhoto ? userPhoto : 'assets/img/icon/user.svg'" [alt]="'components.header.userPhoto' | translate" [ngClass]="{'img-fluid': userPhoto !=''}">
+          </button>
           <div class="dropdown-mobile" [ngClass]="{ 'show': dropdownOpen }">
               <a>{{user}}</a>
               <a>
-                <app-toggle [currentRole]="currentRole"></app-toggle>
+                <app-toggle [currentRole]="currentRole" (roleSwiched)="onSwitchRole($event)"></app-toggle>
               </a>
               <a (click)="logout()">{{'modules.challenge.header.logout' | translate}}<img src="assets/img/icon/logout.svg" alt="logout" style="height: 17px;"></a>
           </div>

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
@@ -31,7 +31,7 @@
           }
           @else {
             <button class="user-mobile userWithPhoto" (click)="toggleDropdown()">
-              <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
+              <img [src]="userPhoto" alt="User" class="img-fluid">
             </button>
           }
           <div class="dropdown-mobile" [ngClass]="{ 'show': dropdownOpen }">

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
@@ -9,7 +9,7 @@
         "components.mainMenu.section2.title" | translate }}</a>
     </ul>
 
-    <div class="d-flex justify-content-end">
+    <div class="d-flex justify-content-end align-items-center">
       <!-- languageSelect -->
       <div class="ms-2 pe-3">
         <label for="languageSelect">
@@ -24,9 +24,16 @@
       <!-- Login -->
       @if(isLoggedIn){
         <div class="user-container-mobile">
-          <button class="user-mobile" (click)="toggleDropdown()">
-            <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
-          </button>
+          @if (!userPhoto) {
+            <button class="user" (click)="toggleDropdown()">
+              <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
+            </button>
+          }
+          @else {
+            <button class="userWithPhoto" (click)="toggleDropdown()">
+              <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
+            </button>
+          }
           <div class="dropdown-mobile" [ngClass]="{ 'show': dropdownOpen }">
               <a>{{user}}</a>
               <a>

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.html
@@ -25,12 +25,12 @@
       @if(isLoggedIn){
         <div class="user-container-mobile">
           @if (!userPhoto) {
-            <button class="user" (click)="toggleDropdown()">
+            <button class="user-mobile" (click)="toggleDropdown()">
               <img src="assets/img/icon/user.svg" alt="User" style="border: none; padding: 0; background: none;">
             </button>
           }
           @else {
-            <button class="userWithPhoto" (click)="toggleDropdown()">
+            <button class="user-mobile userWithPhoto" (click)="toggleDropdown()">
               <img [src]="userPhoto" alt="User" class="img-fluid profilePhoto">
             </button>
           }

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
@@ -109,6 +109,19 @@ $navbar-toggler-transition: none;
       position: relative;
       display: inline-block;
     }
+
+    .userWithPhoto {
+        border-radius: 50%;
+        border: unset;
+        width: 50px;
+        height: 50px;
+        position: relative;
+        display: inline-block;
+    }
+
+    .profilePhoto{
+        border-radius: 50px;
+    }
   
     .dropdown-mobile {
       display: none;

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.scss
@@ -98,31 +98,6 @@ $navbar-toggler-transition: none;
     display: inline-block;
   }
   
-    .user-mobile {
-      border: unset;
-      width: 48px;
-      height: 41px;
-      background: $white;
-      border-radius: 10px;
-      width: 45px;
-      height: 38px;
-      position: relative;
-      display: inline-block;
-    }
-
-    .userWithPhoto {
-        border-radius: 50%;
-        border: unset;
-        width: 50px;
-        height: 50px;
-        position: relative;
-        display: inline-block;
-    }
-
-    .profilePhoto{
-        border-radius: 50px;
-    }
-  
     .dropdown-mobile {
       display: none;
         position: absolute;

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.spec.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.spec.ts
@@ -23,6 +23,8 @@ class MockAuthService {
     return of('')
   }
 
+  getUserPhoto = jest.fn(() => of('https://mock-photo-url.com/avatar.png'))
+
   checkAndHandleExpiredToken = jest.fn()
 }
 

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
@@ -14,7 +14,7 @@ export class MobileNavComponent implements OnInit, OnDestroy{
   user: string = '';
   currentRole: string = ''
   private authSubscription!: Subscription;
-
+  userPhoto: string = ''
 
   constructor(
     @Inject(NavService) public navService: NavService,
@@ -31,8 +31,9 @@ export class MobileNavComponent implements OnInit, OnDestroy{
       this.user = username;
     });
 
-    this._authService.getUserRole().subscribe((userRole) => {
-      this.currentRole = userRole
+    this._authService.getUserPhoto().subscribe((userPhoto) => {
+      this.userPhoto = userPhoto
+      console.log('foto perfil: ', this.userPhoto)
     })
     this._authService.checkAndHandleExpiredToken()
   }

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
@@ -27,14 +27,20 @@ export class MobileNavComponent implements OnInit, OnDestroy{
     });
 
     this._authService.updateUserRoleAndUserNameFromToken();
+    this.loadUserBasicDataMobile()
+    this._authService.checkAndHandleExpiredToken()
+  }
+  loadUserBasicDataMobile():void{
+    this._authService.updateUserRoleAndUserNameFromToken();
     this._authService.getUsername().subscribe((username) => {
       this.user = username;
     });
-
+    this._authService.getUserRole().subscribe((userRole) => {
+      this.currentRole = userRole
+    }) 
     this._authService.getUserPhoto().subscribe((userPhoto) => {
       this.userPhoto = userPhoto
     })
-    this._authService.checkAndHandleExpiredToken()
   }
 
     ngOnDestroy(): void {

--- a/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
+++ b/src/app/core/layout/header/mobile-nav/mobile-nav.component.ts
@@ -33,7 +33,6 @@ export class MobileNavComponent implements OnInit, OnDestroy{
 
     this._authService.getUserPhoto().subscribe((userPhoto) => {
       this.userPhoto = userPhoto
-      console.log('foto perfil: ', this.userPhoto)
     })
     this._authService.checkAndHandleExpiredToken()
   }

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -183,8 +183,6 @@ describe('AuthService', () => {
   it('should return user photo URL from GitHub', fakeAsync(() => {
     const photoUrl = 'https://github.com/avatar.jpg'
     const mockResponse = { avatar_url: photoUrl };
-
-    // Asigna un username al servicio usando spy o cambia visibilidad de la propiedad si necesario
     (service as any).username = 'test-user'
 
     let result = ''

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -183,7 +183,7 @@ describe('AuthService', () => {
   it('should return user photo URL from GitHub', fakeAsync(() => {
     const photoUrl = 'https://github.com/avatar.jpg'
     const mockResponse = { avatar_url: photoUrl };
-    (service as any).username = 'test-user'
+    (service as any).usernameSubject.next('test-user')
 
     let result = ''
     service.getUserPhoto().subscribe(photo => {

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -7,6 +7,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from 'src/environments/environment';
 import { ToastrService } from 'ngx-toastr';
 import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
 
 
 describe('AuthService', () => {
@@ -57,6 +58,8 @@ describe('AuthService', () => {
     const token = btoa(JSON.stringify({ role: 'ADMIN' }));
     localStorage.setItem('authToken', `header.${token}.signature`);
 
+    spyOn(service, 'getUserPhoto').and.returnValue(of('https://github.com/avatar.jpg'));
+
     service.updateUserRoleAndUserNameFromToken();
 
     let role: string | undefined;
@@ -77,6 +80,7 @@ describe('AuthService', () => {
   });
 
   it('should emit updated role when updateUserRoleAndUserNameFromToken is called', fakeAsync(() => {
+    spyOn(service, 'getUserPhoto').and.returnValue(of('https://github.com/avatar.jpg'))
     let initialRole: string | undefined;
     service.getUserRole().pipe(first()).subscribe(r => initialRole = r);
     tick();
@@ -93,6 +97,7 @@ describe('AuthService', () => {
   }));
 
   it('should emit empty role when token is removed', fakeAsync(() => {
+    spyOn(service, 'getUserPhoto').and.returnValue(of('https://github.com/avatar.jpg'))
     const token = btoa(JSON.stringify({ role: 'ADMIN' }));
     localStorage.setItem('authToken', `header.${token}.signature`);
     service.updateUserRoleAndUserNameFromToken();
@@ -175,4 +180,22 @@ describe('AuthService', () => {
     expect(headers.Authorization).toBe('');
   });
 
+  it('should return user photo URL from GitHub', fakeAsync(() => {
+    const photoUrl = 'https://github.com/avatar.jpg'
+    const mockResponse = { avatar_url: photoUrl };
+
+    // Asigna un username al servicio usando spy o cambia visibilidad de la propiedad si necesario
+    (service as any).username = 'test-user'
+
+    let result = ''
+    service.getUserPhoto().subscribe(photo => {
+      result = photo
+    })
+
+    const req = httpMock.expectOne('https://api.github.com/users/test-user')
+    req.flush({ avatar_url: 'https://github.com/avatar.jpg' })
+
+    tick()
+    expect(result).toBe(photoUrl)
+  }))
 });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -3,7 +3,7 @@
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { Observable, of, BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { filter, switchMap, map, tap, catchError } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { ToastrService } from 'ngx-toastr';
 import { TranslateService } from '@ngx-translate/core'
@@ -31,20 +31,19 @@ export class AuthService {
   }
 
   getUserPhoto(): Observable<string> {
-    const url = `${environment.GITHUB_PROFILE_URL}${this.username}`
-    const subject = new BehaviorSubject<string>('')
-    this.http.get<any>(url).subscribe({
-      next: (data) => {
-        const avatarUrl = (data as { avatar_url: string }).avatar_url;
-        this.userPhoto = avatarUrl;
-        subject.next(avatarUrl);
-      },
-      error: (err) => {
-        console.error('Error fetching GitHub avatar:', err);
-        subject.next('error');
-      }
-    })
-    return subject.asObservable();
+    return this.usernameSubject.asObservable().pipe(
+      filter(username => username !== ''),
+      switchMap(username =>
+        this.http.get<{ avatar_url: string }>(`${environment.GITHUB_PROFILE_URL}${username}`).pipe(
+          map(response => response.avatar_url),
+          tap(url => { this.userPhoto = url }),
+          catchError(err => {
+            console.error('Error fetching GitHub avatar:', err);
+            return of('');
+          })
+        )
+      )
+    );
   }
 
   getUserId(): Observable<string | null> {
@@ -70,9 +69,6 @@ export class AuthService {
       this.usernameSubject.next(this.username);
       const userId = decodedToken?.uuid ?? null;
       this.userIdSubject.next(userId);
-      this.getUserPhoto().subscribe(photo => {
-        console.log('Foto del perfil dentro del subscribe:', photo);
-      });
     } else {
       this.userRoleSubject.next('');
       this.usernameSubject.next('');

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -22,10 +22,29 @@ export class AuthService {
   private isLoggedInSubject = new BehaviorSubject<boolean>(this.checkAuthToken());
   public isLoggedIn$: Observable<boolean> = this.isLoggedInSubject.asObservable();
 
+  public userPhoto: string | null = ''
+
   constructor(private http: HttpClient, private router: Router, private toastr: ToastrService, private translate: TranslateService) {
     this.translate.addLangs(['en', 'es', 'ca'])
     this.translate.setDefaultLang('ca')
     this.translate.use('ca')
+  }
+
+  getUserPhoto(): Observable<string> {
+    const url = `${environment.GITHUB_PROFILE_URL}${this.username}`
+    const subject = new BehaviorSubject<string>('')
+    this.http.get<any>(url).subscribe({
+      next: (data) => {
+        const avatarUrl = (data as { avatar_url: string }).avatar_url;
+        this.userPhoto = avatarUrl;
+        subject.next(avatarUrl);
+      },
+      error: (err) => {
+        console.error('Error fetching GitHub avatar:', err);
+        subject.next('error');
+      }
+    })
+    return subject.asObservable();
   }
 
   getUserId(): Observable<string | null> {
@@ -51,6 +70,9 @@ export class AuthService {
       this.usernameSubject.next(this.username);
       const userId = decodedToken?.uuid ?? null;
       this.userIdSubject.next(userId);
+      this.getUserPhoto().subscribe(photo => {
+        console.log('Foto del perfil dentro del subscribe:', photo);
+      });
     } else {
       this.userRoleSubject.next('');
       this.usernameSubject.next('');

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -1,7 +1,9 @@
 {
     "components": {
         "footer": { },
-        "header": { },
+        "header": { 
+            "userPhoto": "Foto de l'usuari"
+        },
         "mainMenu": {
             "section0": {
                 "title": "Inici"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,7 +1,9 @@
 {
     "components": {
         "footer": { },
-        "header": { },
+        "header": { 
+            "userPhoto": "user's photo"
+        },
         "mainMenu": {
             "section0": {
                 "title": "Start"

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1,7 +1,9 @@
 {
     "components": {
         "footer": { },
-        "header": { },
+        "header": { 
+            "userPhoto": "Foto del usuario"
+        },
         "mainMenu": {
             "section0": {
                 "title": "Inicio"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -38,5 +38,6 @@ export const environment = {
   GITHUB_CLIENT_ID: 'Ov23liMlfGdUlcA569gk',
   AUTH_REDIRECT_URL: 'http://dev.ita-challenges.eurecatacademy.org/ita-challenge/challenges',
   AUTH_BASIC_URL: 'http://dev.ita-challenges.eurecatacademy.org/ita-challenge/',
-  AUTH_SWITCH_ROLE: '/auth/switch-role'
+  AUTH_SWITCH_ROLE: '/auth/switch-role',
+  GITHUB_PROFILE_URL: 'https://api.github.com/users/'
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -38,5 +38,6 @@ export const environment = {
   GITHUB_CLIENT_ID: 'Ov23liMlfGdUlcA569gk',
   AUTH_REDIRECT_URL: 'http://localhost:4200/ita-challenge/challenges',
   AUTH_BASIC_URL: 'http://localhost:4200/ita-challenge/',
-  AUTH_SWITCH_ROLE: '/auth/switch-role'
+  AUTH_SWITCH_ROLE: '/auth/switch-role',
+  GITHUB_PROFILE_URL: 'https://api.github.com/users/'
 }

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -21,3 +21,27 @@ a{
 .link{
     color:#BA007C;
 }
+
+.user-mobile, .user {
+    border: unset;
+    background: $white;
+    border-radius: 10px;
+    width: 45px;
+    height: 38px;
+    position: relative;
+    display: inline-block;
+}
+
+.userWithPhoto {
+    border-radius: 50%;
+    border: unset;
+    width: 40px;
+    height: 40px;
+    position: relative;
+    padding: 0;
+    display: inline-block;
+}
+
+.profilePhoto{
+    border-radius: 50px;
+}

--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -40,8 +40,5 @@ a{
     position: relative;
     padding: 0;
     display: inline-block;
-}
-
-.profilePhoto{
-    border-radius: 50px;
+    overflow: hidden;
 }


### PR DESCRIPTION
### Description
This PR completes task **433**, part of user story 388 - "As a user, I can see my role and be able to modify it in the profile drop-down menu.".

A GET request was made to retrieve the user's profile picture URL, and it was added to the navbar, replacing the profile icon.
In addition, a refactor of shared styles was carried out.
Reusable style rules were extracted and moved into the _global.scss file to promote consistency and reduce duplication across components.

### How to test it:
- Sign in with github
- Check if your github profile image is displayed in the menu.

### Before and after comparison
**Before:**
![image](https://github.com/user-attachments/assets/ff2a7abd-e20a-4e89-be72-db46fe628fd8)
![image](https://github.com/user-attachments/assets/0752b939-fc56-4901-a1a2-dc6bbb792e61)

**After (desktop):**
![image](https://github.com/user-attachments/assets/4893c4f6-815d-4a69-9b67-ac0da44cfc59)

**After (mobile):**
![image](https://github.com/user-attachments/assets/32f1d6df-94d4-4e49-9201-23d3bb353dd0)

### Files changed:
- environmet
- auth.service
- desktop-nav
- mobile-nav
- _global.scss


### Auto self-check:

- [x] I tested my changes locally and verified they work as expected
- [ ] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x] Title, description, and changelog (if needed) are filled in correctly
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [ ] All automated checks (like SonarCloud) have passed
- [x] I responded to all previous review comments and only resolved those I truly addressed