### PR TITLE
feat(user): submit solution and update solved counter(#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
   - Automatic redirection upon token expiration (#422)
 
 - show times solved counter in the challenge list and detail (#408)
+- Submit solution and update solved counter (feature#409)
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to
   - Automatic redirection upon token expiration (#422)
 
 - show times solved counter in the challenge list and detail (#408)
-- Submit solution and update solved counter (feature#409)
+
+- [Added] Submit solution and update solved counter (Taiga [#389], PR [#409])
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
   - Added logic to allow user role switching (#401)
   - Automatic redirection upon token expiration (#422)
 
-- show times solved counter in the challenge list and detail (#408)
+- [Added] show times solved counter in the challenge list and detail (Taiga [#389], PR [#408])
 
 - [Added] Submit solution and update solved counter (Taiga [#389], PR [#409])
 

--- a/src/app/models/user-solution.interface.ts
+++ b/src/app/models/user-solution.interface.ts
@@ -16,3 +16,9 @@ export interface SolutionsUser {
   uuid: string
   solutionText: string
 }
+
+export interface SubmitSolutionResponse {
+  solution_text: string
+  isSolved?: boolean
+  timesSolved?: number
+}

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.spec.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { I18nModule } from '../../../../../assets/i18n/i18n.module';
 import { DynamicTranslatePipe } from 'src/app/pipes/dynamic-translate.pipe';
 import { provideRouter } from '@angular/router';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { ChallengeTab } from 'src/app/shared/enums/challenge-tab.enum';
 import { EventEmitter } from '@angular/core';
 import { ChallengeService } from 'src/app/services/challenge.service';
@@ -75,16 +75,24 @@ describe('ChallengeHeaderComponent', () => {
   });
 
   it('should open send solution modal', () => {
+
+    const timesSolvedSubject = new Subject<number>();
     const mockModalRef = {
        componentInstance: {
         idChallenge: '',
         userId: '',
-        solutionAccepted: new EventEmitter<void>() } };
+        solutionAccepted: new EventEmitter<void>(),
+        timesSolvedUpdated: timesSolvedSubject
+     } 
+    };
     jest.spyOn(modalService, 'open').mockReturnValue(mockModalRef as any);
     component.idChallenge = 'testChallengeId';
     component.openSendSolutionModal();
 
     expect(mockModalRef.componentInstance.idChallenge).toBe('testChallengeId');
+
+    timesSolvedSubject.next(5)
+    expect(component.timesSolved).toBe(5)
   });
 
   it('should start challenge and navigate', async () => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -47,7 +47,7 @@ export class ChallengeHeaderComponent implements OnInit {
   challenge_title: string | undefined = ''
   challenge_date: Date | undefined
   challenge_level: string | undefined
-  challenge_timesSolved: number = 0
+  @Input() timesSolved: number = 0
 
   challengeStarted: boolean = false
   solutionSent: boolean = false
@@ -133,7 +133,7 @@ export class ChallengeHeaderComponent implements OnInit {
     });
 
     modalRef.componentInstance.timesSolvedUpdated.subscribe((newCount: number) => {
-      this.challenge_timesSolved = newCount
+      this.timesSolved = newCount
     })
   }
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -47,6 +47,7 @@ export class ChallengeHeaderComponent implements OnInit {
   challenge_title: string | undefined = ''
   challenge_date: Date | undefined
   challenge_level: string | undefined
+  challenge_timesSolved: number = 0
 
   challengeStarted: boolean = false
   solutionSent: boolean = false
@@ -130,6 +131,10 @@ export class ChallengeHeaderComponent implements OnInit {
     modalRef.componentInstance.solutionAccepted.subscribe(() => {
       this.onSolutionAccepted();
     });
+
+    modalRef.componentInstance.timesSolvedUpdated.subscribe((newCount: number) => {
+      this.challenge_timesSolved = newCount
+    })
   }
 
   onSolutionAccepted(): void {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -47,7 +47,6 @@ export class ChallengeHeaderComponent implements OnInit {
   challenge_title: string | undefined = ''
   challenge_date: Date | undefined
   challenge_level: string | undefined
-  @Input() timesSolved: number = 0
 
   challengeStarted: boolean = false
   solutionSent: boolean = false

--- a/src/app/modules/modals/send-solution-modal/send-solution-modal.component.ts
+++ b/src/app/modules/modals/send-solution-modal/send-solution-modal.component.ts
@@ -5,6 +5,7 @@ import { ChallengeService } from '../../../services/challenge.service';
 import { AuthService } from '../../../services/auth.service';
 import { SolutionStatus } from 'src/app/models/user-solution-status.enum';
 import { ChallengeTab } from 'src/app/shared/enums/challenge-tab.enum';
+import { SubmitSolutionResponse } from 'src/app/models/user-solution.interface';
 
 @Component({
   selector: 'app-send-solution-modal',
@@ -52,10 +53,8 @@ export class SendSolutionModalComponent {
       SolutionStatus.ENDED,
       this.solutionText
     ).subscribe({
-      next: (response) => {
-        if ('timesSolved' in response) {
-          this.timesSolvedUpdated.emit(response.timesSolved);
-        }
+      next: (response: SubmitSolutionResponse) => {
+        this.timesSolvedUpdated.emit(response.timesSolved);
         const solutionText = response.solution_text;
         this.solutionService.solutionText(solutionText);
         this.solutionSubmitted.emit(solutionText); 

--- a/src/app/modules/modals/send-solution-modal/send-solution-modal.component.ts
+++ b/src/app/modules/modals/send-solution-modal/send-solution-modal.component.ts
@@ -23,7 +23,7 @@ export class SendSolutionModalComponent {
   solutionText: string = '';
   @Output() solutionAccepted = new EventEmitter<boolean>();
   @Output() solutionSubmitted = new EventEmitter<string>();
-
+  @Output() timesSolvedUpdated = new EventEmitter<number>();
   ngOnInit(): void {
     this.getLanguageId(); 
     this.getSolutionText(); 
@@ -53,6 +53,9 @@ export class SendSolutionModalComponent {
       this.solutionText
     ).subscribe({
       next: (response) => {
+        if ('timesSolved' in response) {
+          this.timesSolvedUpdated.emit(response.timesSolved);
+        }
         const solutionText = response.solution_text;
         this.solutionService.solutionText(solutionText);
         this.solutionSubmitted.emit(solutionText); 

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
-import { BehaviorSubject, catchError, of, Subject, type Observable } from 'rxjs'
+import { BehaviorSubject, catchError, map, of, Subject, type Observable } from 'rxjs'
 import { environment } from 'src/environments/environment'
 import { type DataSolution } from '../models/data-solution.model'
 import { type UserSolution } from '../models/user-solution.interface'
@@ -79,6 +79,14 @@ export class SolutionService {
         }
       }
     ).pipe(
+      map((response) => {
+      // Aquí inyectas los datos que aún no te da el backend
+        return {
+          ...response,
+          isSolved: true,
+          timesSolved: 1 // valor hardcodeado por ahora
+        }
+      }),
       catchError(() => {
         return of({ isSolved: true, timesSolved: 10 });
       })

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -86,9 +86,6 @@ export class SolutionService {
           isSolved: true,
           timesSolved: 1 // valor hardcodeado por ahora
         }
-      }),
-      catchError(() => {
-        return of({ isSolved: true, timesSolved: 10 });
       })
     );
   }

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable, inject } from '@angular/core'
-import { BehaviorSubject, of, Subject, type Observable } from 'rxjs'
+import { BehaviorSubject, catchError, of, Subject, type Observable } from 'rxjs'
 import { environment } from 'src/environments/environment'
 import { type DataSolution } from '../models/data-solution.model'
 import { type UserSolution } from '../models/user-solution.interface'
@@ -78,6 +78,10 @@ export class SolutionService {
           'Content-Type': 'application/json'
         }
       }
+    ).pipe(
+      catchError(() => {
+        return of({ isSolved: true, timesSolved: 10 });
+      })
     );
   }
 

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -3,7 +3,7 @@ import { Injectable, inject } from '@angular/core'
 import { BehaviorSubject, catchError, map, of, Subject, type Observable } from 'rxjs'
 import { environment } from 'src/environments/environment'
 import { type DataSolution } from '../models/data-solution.model'
-import { type UserSolution } from '../models/user-solution.interface'
+import { SubmitSolutionResponse, type UserSolution } from '../models/user-solution.interface'
 import { ChallengeTab } from 'src/app/shared/enums/challenge-tab.enum'
 
 @Injectable({
@@ -79,11 +79,11 @@ export class SolutionService {
         }
       }
     ).pipe(
-      map((response) => {
+      map((response: SubmitSolutionResponse) => {
         return {
           ...response,
           isSolved: true,
-          timesSolved: 1 
+          timesSolved: response.timesSolved ?? 1
         }
       })
     );

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -80,11 +80,10 @@ export class SolutionService {
       }
     ).pipe(
       map((response) => {
-      // Aquí inyectas los datos que aún no te da el backend
         return {
           ...response,
           isSolved: true,
-          timesSolved: 1 // valor hardcodeado por ahora
+          timesSolved: 1 
         }
       })
     );


### PR DESCRIPTION
This PR completes task 409, part of user story 389 - " As a student, I can save my solution at the end of the challenge and the challenge completion counter will be updated. "


This PR mocks the backend response in the service function that performs the HTTP PUT request to save a solution and update the timesSolved counter.

When the user clicks "Finalizar", the updated timesSolved value is shown in the UI, reflecting the latest number of times the challenge has been completed.

To properly test this PR given the current limitations (and since modifying solutions with status ENDED is not allowed), the ideal test flow is:

**Test Flow to Validate This PR**
**From the Mentor role:**
- Create a new challenge that does not yet have any associated solutions.

**From the User (or Student) role:**
- Access the newly created challenge.
- Submit a first solution.
- Upon clicking "Finish", the following should happen:
- A PUT request is sent to the backend to save the solution and update the timesSolved counter.
- The updated value should be reflected in the UI (timesSolved = 1).

Also validate that:

- The PUT request is executed correctly.
- The timesSolved counter is updated in the UI after finishing.
- There are no backend errors related to ENDED.

Demo test: 

https://github.com/user-attachments/assets/6b75c56a-cf38-4aeb-af2e-d1f1ef0a49a0



**PR Author Self-check**

- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x] Title, description, and changelog (if needed) are filled in correctly
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [x] All automated checks (like SonarCloud) have passed(except coverage)
- [x] I responded to all previous review comments and only resolved those I truly addressed