### PR TITLE
feat(user): show times solved counter in the challenge list and detail(#408)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 - Toggle Switch role
 
+- show times solved counter in the challenge list and detail
+
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -14,6 +14,7 @@ export class Challenge {
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []
+  timesSolved: number
 
   constructor (element: any) {
     this.id_challenge = element.id_challenge
@@ -24,6 +25,7 @@ export class Challenge {
     this.favorites_count = element.favorites_count || 0
     this.saved_count = element.saved_count || 0
     this.timesFavorite = element.timesFavorite || 0
+    this.timesSolved = element.timesSolved || 0
     this.detail = element.detail
 
     element.languages.forEach((language: Language) => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -33,7 +33,7 @@
       </span>
       <span class="stat">
         <img src="assets/img/icon/bullseye.svg" alt="Bullseye">
-        87%
+        <span class="txt">{{timesSolved}}</span>
       </span>
       <span class="stat" [ngbTooltip]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)" (click)="toggleBookmark($event)" (keydown.enter)="toggleBookmark($event)" [attr.aria-pressed]="isBookmarked">
         <img *ngIf="!isBookmarked" src="assets/img/icon/bookmark.svg" [attr.alt]="'tooltips.bookmarks.unsaved' | translate">

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -40,6 +40,7 @@ export class ChallengeHeaderComponent implements OnInit {
   @Input() isBookmarked: boolean = false
   @Input() bookmarks_count: number = 0
 
+  @Input() timesSolved: number = 0
   @Output() startChallenge = new EventEmitter<boolean>()
   @Output() favoritesUpdated = new EventEmitter<number>()
 

--- a/src/app/modules/challenge/components/challenge/challenge.component.html
+++ b/src/app/modules/challenge/components/challenge/challenge.component.html
@@ -6,6 +6,7 @@
         [activeId]="activeId"
         [idChallenge]="idChallenge"
         [favorites_count]="challenge.timesFavorite || 0"
+        [timesSolved]="challenge.timesSolved"
         (startChallenge)="onStartChallenge($event)"
         (favoritesUpdated)="onFavoritesUpdated($event)"
         [isFavorite]="isFavoriteChallenge(challenge.id_challenge)"

--- a/src/app/modules/challenge/components/challenge/challenge.component.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.ts
@@ -36,7 +36,7 @@ export class ChallengeComponent implements OnInit, OnDestroy {
   languages: Language[] = []
   activeId: ChallengeTab = ChallengeTab.DETAILS
   challengeTab = ChallengeTab;
-
+  timesSolved?: number
   isEditorChallengeVisible = false
   startChallenge: boolean = false
   challengeStarted: boolean = false
@@ -112,6 +112,7 @@ export class ChallengeComponent implements OnInit, OnDestroy {
       this.notes = this.challenge.detail.notes
       this.popularity = this.challenge.popularity
       this.languages = this.challenge.languages
+      this.timesSolved = this.challenge.timesSolved
     })
   }
 }

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -42,6 +42,7 @@
         [level]="challenge.level" [popularity]="challenge.popularity" [languages]="challenge.languages"
         [id]="challenge.id_challenge" 
         [favorites_count]="challenge.timesFavorite || 0"
+        [challenge_timesSolved]="challenge.timesSolved || timesSolved"
         [isFavorite]="isFavoriteChallenge(challenge.id_challenge)">
       </app-challenge-card>
     </div>

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -38,6 +38,7 @@ export class StarterComponent implements OnInit {
 
   isAdmin: boolean = false
   favoriteChallenges: string[] = []
+  timesSolved: number = 0
 
   constructor (
     @Inject(StarterService) private readonly starterService: StarterService,

--- a/src/app/services/starter.service.spec.ts
+++ b/src/app/services/starter.service.spec.ts
@@ -37,7 +37,8 @@ describe('StarterService', () => {
       })),
       favorites_count: 0,
       saved_count: 0,
-      timesFavorite: 0
+      timesFavorite: 0,
+      timesSolved: 0
     }))
   })
 

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -38,7 +38,7 @@
 
       <div class="stat d-flex align-items-center" [ngbTooltip]="'tooltips.startedFinished' | translate">
         <div><img src="assets/img/icon/bullseye.svg" alt="Bullseye"></div>
-        <div class="txt">87%</div>
+        <div class="txt">{{challenge_timesSolved}}</div>
       </div>
 
       <button class="stat d-flex align-items-center bookmark-button"

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -25,6 +25,8 @@ export class ChallengeCardComponent {
   @Input() id = ''
   @Input() favorites_count: number = 0
   @Input() isFavorite: boolean = false
+  @Input() isBookmarked: boolean = false
+  @Input() bookmarks_count: number = 0
   @Input() challenge_timesSolved: number = 0
 
   get currentLang (): string {

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -25,8 +25,7 @@ export class ChallengeCardComponent {
   @Input() id = ''
   @Input() favorites_count: number = 0
   @Input() isFavorite: boolean = false
-  @Input() isBookmarked: boolean = false
-  @Input() bookmarks_count: number = 0
+  @Input() challenge_timesSolved: number = 0
 
   get currentLang (): string {
     return this.translate.currentLang


### PR DESCRIPTION
This PR completes task 408, part of user story 389 - " As a student, I can save my solution at the end of the challenge and the challenge completion counter will be updated. "

**Initialize and propagate timesSolved from parent components to challenge list and detail views**

- The timesSolved variable is initialized with a default value of 0 to ensure consistent display in the UI.

The actual value of timesSolved is retrieved from the backend response in:

- The parent component of the challenge list (where each challenge is represented as a card).

- The component responsible for the challenge detail page.

The value is then passed down to the respective child components (cards or detail view) to correctly display how many times each challenge has been solved, both in the general list view and the individual detail view.

**Before:** 
![image](https://github.com/user-attachments/assets/8be3cb3c-fe97-43b4-8e47-d05b4525feab)
![image](https://github.com/user-attachments/assets/69a8fb5a-0004-4eef-9afa-b9e99ca81cf9)

**After:**
![image](https://github.com/user-attachments/assets/0e85a3b9-d445-49a9-a2ca-d8f08ae6d98e)
![image](https://github.com/user-attachments/assets/e0fd7b98-69a2-4429-89b6-f8fd6646274c)


**How to test**
Challenge list:

- Go to the main screen where challenges are listed.

- Check that each card displays "0" in the times solved counter (default value).

Challenge detail:

- Click on any challenge to open its detail page.

- Confirm that the times solved counter also displays "0".

Note: The value will update from 0 once the backend starts returning actual timesSolved values.

**PR Author Self-check**
- [x] I tested my changes locally and verified they work as expected
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x] Title, description, and changelog (if needed) are filled in correctly
- [x] There are no leftover merge conflicts or unrelated changes from previous branches
- [x] All automated checks (like SonarCloud) have passed
- [x] I responded to all previous review comments and only resolved those I truly addressed