### PR TITLE
PR 1/3 - feat(user solution): display user and mentor solutions after challenge completion (#424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,7 @@ and this project adheres to
 - Submit solution and update solved counter (#389)
 - display user bookmarks on login (#432)
 - remove bookmark count (#431)
-
-
-- Show user solution (mock) alongside mentor solution in completed challenges (Taiga [#424], PR [#627])
-
-- Refactor SolutionService to load user solutions from mock JSON (Taiga [#424], PR [#627])
+- Show user solution (mock) alongside mentor solution in completed challenges (#424)
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to
 - remove bookmark count (#431)
 
 
+- Show user solution (mock) alongside mentor solution in completed challenges (Taiga [#424], PR [#627])
+
+- Refactor SolutionService to load user solutions from mock JSON (Taiga [#424], PR [#627])
+
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 
 - Cleanup pagination logic

--- a/src/app/models/user-solution.interface.ts
+++ b/src/app/models/user-solution.interface.ts
@@ -1,20 +1,8 @@
 export interface UserSolution {
-  offset: number
-  limit: number
-  count: number
-  results: Result[]
-}
-
-export interface Result {
-  id_challenge: string
-  language: string
-  id_user: string
-  solutions: SolutionsUser[]
-}
-
-export interface SolutionsUser {
-  uuid: string
-  solutionText: string
+  uuid_user: string
+  uuid_challenge: string
+  uuid_language: string
+  solution_text: string
 }
 
 export interface SubmitSolutionResponse {

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.spec.ts
@@ -418,5 +418,35 @@ describe('ChallengeInfoComponent', () => {
       const uniqueIds = new Set(result.map((c: any) => c.id_challenge))
       expect(uniqueIds.size).toBe(result.length)
     })
+
+    it('should load user solution if available', async () => {
+      // Arrange
+      const mockUserId: string = 'test-user-id'
+      const mockChallengeId: string = 'test-challenge-id'
+      const mockLanguageId: string = 'test-language-id'
+      const mockSolutionText: string = 'Mock user solution'
+
+      component.idChallenge = mockChallengeId
+      component.languages = [{ id_language: mockLanguageId, language_name: 'JavaScript' }]
+
+      jest.spyOn(component['authService'], 'getUserId').mockReturnValue(of(mockUserId))
+      jest.spyOn(component['solutionService'], 'fetchUserSolution').mockReturnValue(of([
+        {
+          uuid_user: mockUserId,
+          uuid_challenge: mockChallengeId,
+          uuid_language: mockLanguageId,
+          solution_text: mockSolutionText
+        }
+      ]));
+
+      // Act
+      await component.ngOnInit()
+      fixture.detectChanges()
+
+      // Assert
+      expect(component.solutionSent).toBe(true)
+      expect(component.solutionText).toBe(mockSolutionText)
+      expect(component.userSolution).toEqual({ solution_text: mockSolutionText })
+    })
   })
 })

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.spec.ts
@@ -420,15 +420,16 @@ describe('ChallengeInfoComponent', () => {
     })
 
     it('should load user solution if available', async () => {
-      // Arrange
       const mockUserId: string = 'test-user-id'
       const mockChallengeId: string = 'test-challenge-id'
-      const mockLanguageId: string = 'test-language-id'
+      const mockLanguageId: string = 'mock-lang-id'
       const mockSolutionText: string = 'Mock user solution'
 
+      // Prepara valores requeridos
       component.idChallenge = mockChallengeId
       component.languages = [{ id_language: mockLanguageId, language_name: 'JavaScript' }]
 
+      // Mock servicios
       jest.spyOn(component['authService'], 'getUserId').mockReturnValue(of(mockUserId))
       jest.spyOn(component['solutionService'], 'fetchUserSolution').mockReturnValue(of([
         {
@@ -437,10 +438,10 @@ describe('ChallengeInfoComponent', () => {
           uuid_language: mockLanguageId,
           solution_text: mockSolutionText
         }
-      ]));
+      ]))
 
       // Act
-      await component.ngOnInit()
+      await component['loadUserSolutionData']()
       fixture.detectChanges()
 
       // Assert

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -75,18 +75,18 @@ implements OnInit {
 
   mockSolutions = [
     {
-      uuid_user: "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
-      uuid_challenge: "eced92af-3975-488b-b6e7-d3ab6edb5ff6",
-      uuid_language: "660e1b18-0c0a-4262-a28a-85de9df6ac5f",
-      solution_text: "This is the submitted solution"
+      uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
+      uuid_challenge: 'd43a1a4d-ee8f-432d-8f9c-68eda2547dae',
+      uuid_language: '409c9fe8-74de-4db3-81a1-a55280cf92ef',
+      solution_text: 'This is the submitted solution'
     },
     {
-      uuid_user: "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
-      uuid_challenge: "b5c06903-f27b-4057-8220-ad9d957cdce4",
-      uuid_language: "09fabe32-7362-4bfb-ac05-b7bf854c6e0f",
-      solution_text: "This is another user's solution"
+      uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
+      uuid_challenge: 'b5c06903-f27b-4057-8220-ad9d957cdce4',
+      uuid_language: '09fabe32-7362-4bfb-ac05-b7bf854c6e0f',
+      solution_text: 'This is the submitted solution'
     }
-  ];
+  ]
 
   async ngOnInit (): Promise<void> {
     this.authService.getUserRole().subscribe(role => {
@@ -133,19 +133,21 @@ implements OnInit {
     }
 
     this.authService.getUserId().subscribe((userId) => {
-      if (userId === null || userId === '') return;
+      if (userId === null || userId === '') return
 
       const found = this.mockSolutions.find(
         (sol) => sol.uuid_user === userId && sol.uuid_challenge === this.idChallenge
-      );
+      )
 
       if (found !== undefined) {
-        this.solutionSent = true;
-        this.solutionText = found.solution_text;
-        this.userSolution = { solution_text: found.solution_text };
-        this.cdr.detectChanges(); // Si necesitas forzar actualización de vista
+        this.solutionSent = true
+        this.solutionText = found.solution_text
+        this.userSolution = { solution_text: found.solution_text }
+        this.loadSolutions(this.idChallenge, found.uuid_language)
+
+        this.cdr.detectChanges() // Si necesitas forzar actualización de vista
       }
-    });
+    })
   }
 
   ngOnChanges (changes: SimpleChanges): void {

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -136,7 +136,7 @@ implements OnInit {
       if (userId === null || userId === '') return
 
       const found = this.mockSolutions.find(
-        (sol) => sol.uuid_user === userId && sol.uuid_challenge === this.idChallenge
+        (sol) => sol.uuid_user === userId && sol.uuid_challenge === this.idChallenge && this.languages.some(lang => lang.id_language === sol.uuid_language)
       )
 
       if (found !== undefined) {

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -13,7 +13,7 @@ import { type ChallengeDetails } from 'src/app/models/challenge-details.model'
 import { type Example } from 'src/app/models/challenge-example.model'
 import { type Language } from 'src/app/models/language.model'
 import { ChallengeService } from '../../../../services/challenge.service'
-import { type Subscription } from 'rxjs'
+import { firstValueFrom, type Subscription } from 'rxjs'
 import { DataChallenge } from '../../../../models/data-challenge.model'
 import { type Challenge } from '../../../../models/challenge.model'
 import { NgbModal, type NgbNav } from '@ng-bootstrap/ng-bootstrap'
@@ -117,25 +117,24 @@ implements OnInit {
       this.isChallengeStatementVisible = false;
     }
 
-    this.authService.getUserId().subscribe((userId) => {
-      if (userId === null || userId === '') return
+    const userId = await firstValueFrom(this.authService.getUserId())
+    if (userId === null || userId === '') return
 
-      this.solutionService.fetchUserSolution().subscribe((response) => {
-        const match = response.find((solution: any) =>
-          solution.uuid_user === userId &&
-          solution.uuid_challenge === this.idChallenge &&
-          this.languages.some(lang => lang.id_language === solution.uuid_language)
-        )
+    const response = await firstValueFrom(this.solutionService.fetchUserSolution())
 
-        if (match !== undefined && match !== null) {
-          this.solutionSent = true
-          this.solutionText = match.solution_text
-          this.userSolution = { solution_text: match.solution_text }
-          this.loadSolutions(this.idChallenge, String(match.uuid_language))
-          this.cdr.detectChanges()
-        }
-      })
-    })
+    const match = response.find((solution: any) =>
+      solution.uuid_user === userId &&
+      solution.uuid_challenge === this.idChallenge &&
+      this.languages.some(lang => lang.id_language === solution.uuid_language)
+    )
+
+    if (match !== undefined && match !== null) {
+      this.solutionSent = true
+      this.solutionText = match.solution_text
+      this.userSolution = { solution_text: match.solution_text }
+      this.loadSolutions(this.idChallenge, String(match.uuid_language))
+      this.cdr.detectChanges()
+    }
   }
 
   ngOnChanges (changes: SimpleChanges): void {

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -117,6 +117,10 @@ implements OnInit {
       this.isChallengeStatementVisible = false;
     }
 
+    void this.loadUserSolutionData()
+  }
+
+  private async loadUserSolutionData (): Promise<void> {
     const userId = await firstValueFrom(this.authService.getUserId())
     if (userId === null || userId === '') return
 
@@ -126,7 +130,7 @@ implements OnInit {
       solution.uuid_user === userId &&
       solution.uuid_challenge === this.idChallenge &&
       this.languages.some(lang => lang.id_language === solution.uuid_language)
-    )
+    );
 
     if (match !== undefined && match !== null) {
       this.solutionSent = true

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -73,7 +73,7 @@ implements OnInit {
 
   solutionsDummy = [{ solutionName: 'dummy1' }, { solutionName: 'dummy2' }]
 
-  async ngOnInit (): Promise<void> {
+  ngOnInit (): void {
     this.authService.getUserRole().subscribe(role => {
       this.isAdmin = role === 'ADMIN'
     })

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -73,21 +73,6 @@ implements OnInit {
 
   solutionsDummy = [{ solutionName: 'dummy1' }, { solutionName: 'dummy2' }]
 
-  mockSolutions = [
-    {
-      uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
-      uuid_challenge: 'd43a1a4d-ee8f-432d-8f9c-68eda2547dae',
-      uuid_language: '409c9fe8-74de-4db3-81a1-a55280cf92ef',
-      solution_text: 'This is the submitted solution'
-    },
-    {
-      uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
-      uuid_challenge: 'b5c06903-f27b-4057-8220-ad9d957cdce4',
-      uuid_language: '09fabe32-7362-4bfb-ac05-b7bf854c6e0f',
-      solution_text: 'This is the submitted solution'
-    }
-  ]
-
   async ngOnInit (): Promise<void> {
     this.authService.getUserRole().subscribe(role => {
       this.isAdmin = role === 'ADMIN'
@@ -135,18 +120,22 @@ implements OnInit {
     this.authService.getUserId().subscribe((userId) => {
       if (userId === null || userId === '') return
 
-      const found = this.mockSolutions.find(
-        (sol) => sol.uuid_user === userId && sol.uuid_challenge === this.idChallenge && this.languages.some(lang => lang.id_language === sol.uuid_language)
-      )
+      this.solutionService.fetchUserSolution().subscribe((solutions) => {
+        const match = solutions.find(
+          (sol: any) =>
+            sol.uuid_user === userId &&
+            sol.uuid_challenge === this.idChallenge &&
+            this.languages.some(lang => lang.id_language === sol.uuid_language)
+        )
 
-      if (found !== undefined) {
-        this.solutionSent = true
-        this.solutionText = found.solution_text
-        this.userSolution = { solution_text: found.solution_text }
-        this.loadSolutions(this.idChallenge, found.uuid_language)
-
-        this.cdr.detectChanges() // Si necesitas forzar actualización de vista
-      }
+        if (match !== undefined && match !== null) {
+          this.solutionSent = true
+          this.solutionText = match.solution_text
+          this.userSolution = { solution_text: match.solution_text }
+          this.loadSolutions(this.idChallenge, String(match.uuid_language))
+          this.cdr.detectChanges()
+        }
+      })
     })
   }
 

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -120,12 +120,11 @@ implements OnInit {
     this.authService.getUserId().subscribe((userId) => {
       if (userId === null || userId === '') return
 
-      this.solutionService.fetchUserSolution().subscribe((solutions) => {
-        const match = solutions.find(
-          (sol: any) =>
-            sol.uuid_user === userId &&
-            sol.uuid_challenge === this.idChallenge &&
-            this.languages.some(lang => lang.id_language === sol.uuid_language)
+      this.solutionService.fetchUserSolution().subscribe((response) => {
+        const match = response.find((solution: any) =>
+          solution.uuid_user === userId &&
+          solution.uuid_challenge === this.idChallenge &&
+          this.languages.some(lang => lang.id_language === solution.uuid_language)
         )
 
         if (match !== undefined && match !== null) {

--- a/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
+++ b/src/app/modules/challenge/components/challenge-info/challenge-info.component.ts
@@ -73,6 +73,21 @@ implements OnInit {
 
   solutionsDummy = [{ solutionName: 'dummy1' }, { solutionName: 'dummy2' }]
 
+  mockSolutions = [
+    {
+      uuid_user: "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
+      uuid_challenge: "eced92af-3975-488b-b6e7-d3ab6edb5ff6",
+      uuid_language: "660e1b18-0c0a-4262-a28a-85de9df6ac5f",
+      solution_text: "This is the submitted solution"
+    },
+    {
+      uuid_user: "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
+      uuid_challenge: "b5c06903-f27b-4057-8220-ad9d957cdce4",
+      uuid_language: "09fabe32-7362-4bfb-ac05-b7bf854c6e0f",
+      solution_text: "This is another user's solution"
+    }
+  ];
+
   async ngOnInit (): Promise<void> {
     this.authService.getUserRole().subscribe(role => {
       this.isAdmin = role === 'ADMIN'
@@ -116,6 +131,21 @@ implements OnInit {
       this.isEditorChallengeVisible = true;
       this.isChallengeStatementVisible = false;
     }
+
+    this.authService.getUserId().subscribe((userId) => {
+      if (userId === null || userId === '') return;
+
+      const found = this.mockSolutions.find(
+        (sol) => sol.uuid_user === userId && sol.uuid_challenge === this.idChallenge
+      );
+
+      if (found !== undefined) {
+        this.solutionSent = true;
+        this.solutionText = found.solution_text;
+        this.userSolution = { solution_text: found.solution_text };
+        this.cdr.detectChanges(); // Si necesitas forzar actualización de vista
+      }
+    });
   }
 
   ngOnChanges (changes: SimpleChanges): void {

--- a/src/app/services/solution.service.spec.ts
+++ b/src/app/services/solution.service.spec.ts
@@ -86,16 +86,16 @@ describe('SolutionService', () => {
 })
 
   it('should fetch user solutions', (done) => {
-    const userId = 'user123'
+    const expectedUrl = environment.USER_SOLUTION
 
     service.fetchUserSolution().subscribe((data) => {
-      expect(data).toEqual(mockResponse)
+      expect(data).toEqual(mockUserSolution)
       done()
     })
 
-    const req = httpMock.expectOne(`${environment.USER_SOLUTION.replace('{idUser}', userId)}`)
+    const req = httpMock.expectOne(expectedUrl)
     expect(req.request.method).toBe('GET')
-    req.flush(mockResponse)
+    req.flush(mockUserSolution)
   })
 
   it('should send the correct data in PUT request', () => {

--- a/src/app/services/solution.service.spec.ts
+++ b/src/app/services/solution.service.spec.ts
@@ -62,18 +62,28 @@ describe('SolutionService', () => {
   })
 
   it('should check the user solutions', (done) => {
-    const challengeId = 'challenge123'
-    const languageId = 'language123'
+    const challengeId = 'challenge123';
+    const languageId = 'language123';
+
+    const mockUserSolution = {
+      uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
+      uuid_challenge: challengeId,
+      uuid_language: languageId,
+      solution_text: 'Esta es la solución del usuario para el reto FizzBuzz'
+    }
 
     service.getUserSolution(challengeId, languageId).subscribe(data => {
-      expect(data.results[0].solutions[0].uuid).toEqual('dcacb291-b4aa-4029-8e9b-284c8ca80296')
+      expect(data.solution_text).toEqual('Esta es la solución del usuario para el reto FizzBuzz')
       done()
     })
 
-    const req = httpMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_CHALLENGE_USER_SOLUTION}/challenge/${challengeId}/language/${languageId}`)
+    const req = httpMock.expectOne(
+    `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_CHALLENGE_USER_SOLUTION}/challenge/${challengeId}/language/${languageId}`
+    )
+
     expect(req.request.method).toBe('GET')
     req.flush(mockUserSolution)
-  })
+})
 
   it('should fetch user solutions', (done) => {
     const userId = 'user123'

--- a/src/app/services/solution.service.spec.ts
+++ b/src/app/services/solution.service.spec.ts
@@ -85,7 +85,6 @@ describe('SolutionService', () => {
 
     const req = httpMock.expectOne(`${environment.USER_SOLUTION.replace('{idUser}', userId)}`)
     expect(req.request.method).toBe('GET')
-    expect(req.request.headers.get('Content-Type')).toBe('application/json')
     req.flush(mockResponse)
   })
 

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -102,12 +102,22 @@ export class SolutionService {
     this.submitSolutionSubject.next(solution)
   }
 
-  fetchUserSolution (): Observable<any> {
-    return this.http.get<any>(`${environment.USER_SOLUTION}`,
+  fetchUserSolution (): Observable<any[]> {
+    const mockSolutions = [
       {
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      })
+        uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
+        uuid_challenge: 'd43a1a4d-ee8f-432d-8f9c-68eda2547dae',
+        uuid_language: '409c9fe8-74de-4db3-81a1-a55280cf92ef',
+        solution_text: 'Esta es la solución del usuario para el reto FizzBuzz'
+      },
+      {
+        uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
+        uuid_challenge: 'b5c06903-f27b-4057-8220-ad9d957cdce4',
+        uuid_language: '09fabe32-7362-4bfb-ac05-b7bf854c6e0f',
+        solution_text: 'Esta es la solución del usuario para el reto Contador de vocales únicas'
+      }
+    ]
+
+    return of(mockSolutions)
   }
 }

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -102,7 +102,7 @@ export class SolutionService {
     this.submitSolutionSubject.next(solution)
   }
 
-  fetchUserSolution (): Observable<any[]> {
-    return this.http.get<any[]>('../assets/dummy/user-solution.mock.json')
+  fetchUserSolution (): Observable<UserSolution[]> {
+    return this.http.get<UserSolution[]>('../assets/dummy/user-solution.mock.json')
   }
 }

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -103,6 +103,6 @@ export class SolutionService {
   }
 
   fetchUserSolution (): Observable<UserSolution[]> {
-    return this.http.get<UserSolution[]>('../assets/dummy/user-solution.mock.json')
+    return this.http.get<UserSolution[]>(environment.USER_SOLUTION)
   }
 }

--- a/src/app/services/solution.service.ts
+++ b/src/app/services/solution.service.ts
@@ -103,21 +103,6 @@ export class SolutionService {
   }
 
   fetchUserSolution (): Observable<any[]> {
-    const mockSolutions = [
-      {
-        uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
-        uuid_challenge: 'd43a1a4d-ee8f-432d-8f9c-68eda2547dae',
-        uuid_language: '409c9fe8-74de-4db3-81a1-a55280cf92ef',
-        solution_text: 'Esta es la solución del usuario para el reto FizzBuzz'
-      },
-      {
-        uuid_user: '1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d',
-        uuid_challenge: 'b5c06903-f27b-4057-8220-ad9d957cdce4',
-        uuid_language: '09fabe32-7362-4bfb-ac05-b7bf854c6e0f',
-        solution_text: 'Esta es la solución del usuario para el reto Contador de vocales únicas'
-      }
-    ]
-
-    return of(mockSolutions)
+    return this.http.get<any[]>('../assets/dummy/user-solution.mock.json')
   }
 }

--- a/src/assets/dummy/user-solution.mock.json
+++ b/src/assets/dummy/user-solution.mock.json
@@ -1,24 +1,14 @@
-{
-    "uuid_user": "xxx",
-    "challenges": [
-      {
-        "uuid_challenge": "dcacb291-b4aa-4029-8e9b-284c8ca80296",
-        "status": "STARTED",
-        "uuid_language": "xxx",
-        "score": 99
-      },
-      {
-        "uuid_challenge": "f6e0f877-9560-4e68-bab6-7dd5f16b46a5",
-        "status": "ENDED",
-        "uuid_language": "xxx",
-        "score": 99
-      },
-      {
-        "uuid_challenge": "9d2c4e2b-02af-4327-81b2-7dbf5c3f5a7d",
-        "status": "STARTED",
-        "uuid_language": "xxx",
-        "score": 99
-      }
-    ]
+[
+  {
+    "uuid_user": "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
+    "uuid_challenge": "d43a1a4d-ee8f-432d-8f9c-68eda2547dae",
+    "uuid_language": "409c9fe8-74de-4db3-81a1-a55280cf92ef",
+    "solution_text": "Esta es la solución del usuario para el reto FizzBuzz"
+  },
+  {
+    "uuid_user": "1a2b3c4d-5e6f-6a8b-9c0d-1e2f3a4b5c6d",
+    "uuid_challenge": "b5c06903-f27b-4057-8220-ad9d957cdce4",
+    "uuid_language": "09fabe32-7362-4bfb-ac05-b7bf854c6e0f",
+    "solution_text": "Esta es la solución del usuario para el reto Contador de vocales únicas"
   }
-  
+]


### PR DESCRIPTION
This PR completes task 424, part of user story 394 — "As a student, I can see my solution when I complete the challenge and when I click on the challenge from the list."

### **Display user solution (mock) alongside mentor solution in completed challenges**

**Pull Request Description:**
This PR adds the logic to display the user's submitted solution (from a local mock file) alongside the mentor's solution in challenges that have already been completed.

**🔧 Changes included:**
Updated challenge-info.component.ts to load and render both the user's and mentor's solutions.
- Refactored SolutionService to fetch user solutions from a local mock JSON file.
- Replaced all any types with the corrected UserSolution interface.
- Fixed and updated the UserSolution interface to match the actual structure of the mock data.
- Modified the mock file user-solution.mock.json located at /assets/dummy/.
- Updated the unit test for SolutionService to reflect the mock data usage, including removing an invalid header check.

These changes are part of the foundation for full backend integration of user-submitted solutions in the challenge detail view.

**✅ How to test it**
- Open the mock file located at: src/assets/dummy/user-solution.mock.json
- Replace the "uuid_user" value with your own user UUID.
- Log in and navigate to the challenges:
     FizzBuzz personalizado
     Contador de vocales únicas
- In both challenges, go to the "Soluciones" tab.
- You should see your solution displayed alongside the mentor's solution, as long as your user UUID matches the one in the mock.

**PR Author Self-check**
- [x]  I tested my changes locally and verified they work as expected
- [x]  The PR has a clear and focused purpose (only one feature, fix or refactor)
- [x]  Title, description, and changelog (if needed) are filled in correctly
- [x]  There are no leftover merge conflicts or unrelated changes from previous branches
- [ ]  All automated checks (like SonarCloud) have passed
- [x]  I responded to all previous review comments and only resolved those I truly addressed

> **Note**
> 
> Removed the `async` keyword from the `ngOnInit()` method in `challenge-info.component.ts` because SonarCloud reported the following issue:
> 
> > `ngOnInit` matches the `OnInit` interface declared in `@angular/core`, so it should not be `async`.
> 
> This method was already defined as `async` before my changes, but to follow Angular best practices and match the interface signature (`ngOnInit(): void`), I removed the keyword.
> 
> The call to the async method `loadUserSolutionData()` remains prefixed with `void`, which is safe here since the returned `Promise` is intentionally not awaited.
