### PR TITLE
PR 2/3 - feat(bookmark): display user bookmarks on login (#432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ and this project adheres to
 
 ### [ita-challenges-frontend-3.1.35-RELEASE] - 2025-05-28
 
+- [Added] 
+
 - Toggle Switch role (#400)
-  - Added logic to allow user role switching (#401)
-  - Add redirection upon user role switching (#402)
-  - Automatic redirection upon token expiration (#422)
-
-- [Added] show times solved counter in the challenge list and detail (Taiga [#389], PR [#408])
-
-- [Added] Submit solution and update solved counter (Taiga [#389], PR [#409])
+- Added logic to allow user role switching (#401)
+- Add redirection upon user role switching (#402)
+- Automatic redirection upon token expiration (#422)
+- show times solved counter in the challenge list and detail (#389)
+- Submit solution and update solved counter (#389)
+- display user bookmarks on login (#432)
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -11,6 +11,7 @@ export class Challenge {
   favorites_count: number
   saved_count: number
   timesFavorite: number
+  bookmarked?: boolean
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -31,6 +31,7 @@ export class Challenge {
     this.timesSolved = element.timesSolved || 0
 
     this.bookmarked = element.bookmarked || false
+
     this.detail = element.detail
 
     element.languages.forEach((language: Language) => {

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -11,7 +11,6 @@ export class Challenge {
   favorites_count: number
   saved_count: number
   timesFavorite: number
-  bookmarked?: boolean
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -15,6 +15,7 @@ export class Challenge {
   languages: Language[] = []
   solutions: Solution[] = []
   timesSolved: number
+  bookmarked: boolean
 
   constructor (element: any) {
     this.id_challenge = element.id_challenge
@@ -26,6 +27,7 @@ export class Challenge {
     this.saved_count = element.saved_count || 0
     this.timesFavorite = element.timesFavorite || 0
     this.timesSolved = element.timesSolved || 0
+    this.bookmarked = element.bookmarked || false
     this.detail = element.detail
 
     element.languages.forEach((language: Language) => {

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -14,6 +14,7 @@ export class Challenge {
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []
+
   timesSolved: number
   bookmarked: boolean
 
@@ -26,7 +27,9 @@ export class Challenge {
     this.favorites_count = element.favorites_count || 0
     this.saved_count = element.saved_count || 0
     this.timesFavorite = element.timesFavorite || 0
+
     this.timesSolved = element.timesSolved || 0
+
     this.bookmarked = element.bookmarked || false
     this.detail = element.detail
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -35,7 +35,7 @@
         <img src="assets/img/icon/bullseye.svg" alt="Bullseye">
         <span class="txt">{{timesSolved}}</span>
       </span>
-      <span class="stat" [ngbTooltip]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)" (click)="toggleBookmark($event)" (keydown.enter)="toggleBookmark($event)" [attr.aria-pressed]="isBookmarked">
+      <span class="stat" [ngbTooltip]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)" (click)="toggleBookmark($event)" (keydown.enter)="toggleBookmark($event)" [attr.aria-pressed]="isBookmarked" [attr.aria-label]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)">
         <img *ngIf="!isBookmarked" src="assets/img/icon/bookmark.svg" [attr.alt]="'tooltips.bookmarks.unsaved' | translate">
         <img *ngIf=" isBookmarked" src="assets/img/icon/bookmark-filled.svg" [attr.alt]="'tooltips.bookmarks.saved' | translate">
         <span class="txt">{{ bookmarks_count }}</span>

--- a/src/app/modules/challenge/components/challenge/challenge.component.html
+++ b/src/app/modules/challenge/components/challenge/challenge.component.html
@@ -10,7 +10,7 @@
         (startChallenge)="onStartChallenge($event)"
         (favoritesUpdated)="onFavoritesUpdated($event)"
         [isFavorite]="isFavoriteChallenge(challenge.id_challenge)"
-
+        [isBookmarked]="isBookmarkedChallenge(challenge.id_challenge)"
 >   </app-challenge-header>
 
     <app-challenge-info

--- a/src/app/modules/challenge/components/challenge/challenge.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.spec.ts
@@ -19,6 +19,7 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { CookieService } from 'ngx-cookie-service'
 import { registerLocaleData } from '@angular/common'
 import localeCa from '@angular/common/locales/ca'
+import { AuthService } from 'src/app/services/auth.service'
 
 registerLocaleData(localeCa)
 
@@ -27,8 +28,13 @@ describe('ChallengeComponent', () => {
   let fixture: ComponentFixture<ChallengeComponent>
   let mockChallengeService: any
   let cookieService: CookieService
+  let getUserBookmarksSpy: jasmine.Spy
+  let getUserFavoritesSpy: jasmine.Spy
 
   beforeEach(async () => {
+    getUserBookmarksSpy = jasmine.createSpy('getUserBookmarks').and.returnValue(of(['id1', 'id2']))
+    getUserFavoritesSpy = jasmine.createSpy('getUserFavorites').and.returnValue(of(['id3']))
+
     mockChallengeService = {
       getChallengeById: jasmine.createSpy('getChallengeById').and.returnValue(of({
         challenge_title: '',
@@ -45,7 +51,14 @@ describe('ChallengeComponent', () => {
         popularity: 0,
         languages: [],
         timesFavorite: 0
-      }))
+      })),
+      getUserBookmarks: getUserBookmarksSpy,
+      getUserFavorites: getUserFavoritesSpy
+    }
+    const mockAuthService = {
+      isUserLoggedIn: () => true,
+      getUserId: () => of('mock-user-id'),
+      getUserRole: () => of('ROLE_USER')
     }
 
     await TestBed.configureTestingModule({
@@ -82,6 +95,7 @@ describe('ChallengeComponent', () => {
           provide: ChallengeService,
           useValue: mockChallengeService
         },
+        { provide: AuthService, useValue: mockAuthService },
         CookieService,
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
@@ -228,6 +242,14 @@ describe('ChallengeComponent', () => {
     expect(component.activeId).toBe(newActiveId)
   })
 
+  it('should correctly determine if a challenge is bookmarked', () => {
+    component.bookmarkedChallenges = ['id-1', 'id-2']
+    expect(component.isBookmarkedChallenge('id-1')).toBeTruthy()
+    expect(component.isBookmarkedChallenge('id-3')).toBeFalsy()
+  })
 
-  
+  it('should fetch and store bookmarked challenges on init', () => {
+    expect(mockChallengeService.getUserBookmarks).toHaveBeenCalled()
+    expect(component.bookmarkedChallenges).toEqual(['id1', 'id2'])
+  })
 })

--- a/src/app/modules/challenge/components/challenge/challenge.component.ts
+++ b/src/app/modules/challenge/components/challenge/challenge.component.ts
@@ -41,6 +41,7 @@ export class ChallengeComponent implements OnInit, OnDestroy {
   startChallenge: boolean = false
   challengeStarted: boolean = false
   favoriteChallenges: string[] = []
+  bookmarkedChallenges: string[] = []
 
   private readonly route = inject(ActivatedRoute)
   private readonly router = inject(Router)
@@ -69,6 +70,14 @@ export class ChallengeComponent implements OnInit, OnDestroy {
               console.error('Error getting favorites:', err)
             }
           })
+          this.challengeService.getUserBookmarks(userId).subscribe({
+            next: (bookmarks: string[]) => {
+              this.bookmarkedChallenges = bookmarks
+            },
+            error: (err) => {
+              console.error('Error getting bookmarks:', err)
+            }
+          })
         }
       })
     }
@@ -77,6 +86,10 @@ export class ChallengeComponent implements OnInit, OnDestroy {
   isFavoriteChallenge (challengeId: string): boolean {
     const result = this.favoriteChallenges.includes(challengeId)
     return result
+  }
+
+  isBookmarkedChallenge (challengeId: string): boolean {
+    return this.bookmarkedChallenges.includes(challengeId)
   }
 
   onStartChallenge (started: boolean): void {

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -44,7 +44,7 @@
         [favorites_count]="challenge.timesFavorite || 0"
         [challenge_timesSolved]="challenge.timesSolved || timesSolved"
         [isFavorite]="isFavoriteChallenge(challenge.id_challenge)"
-        [isBookmarked]="challenge.bookmarked">
+        [isBookmarked]="isBookmarkedChallenge(challenge.id_challenge)">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.html
+++ b/src/app/modules/starter/components/starter/starter.component.html
@@ -43,7 +43,8 @@
         [id]="challenge.id_challenge" 
         [favorites_count]="challenge.timesFavorite || 0"
         [challenge_timesSolved]="challenge.timesSolved || timesSolved"
-        [isFavorite]="isFavoriteChallenge(challenge.id_challenge)">
+        [isFavorite]="isFavoriteChallenge(challenge.id_challenge)"
+        [isBookmarked]="challenge.bookmarked">
       </app-challenge-card>
     </div>
   </div>

--- a/src/app/modules/starter/components/starter/starter.component.spec.ts
+++ b/src/app/modules/starter/components/starter/starter.component.spec.ts
@@ -9,6 +9,7 @@ import { of, BehaviorSubject } from 'rxjs'
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import mockChallenges from 'src/mocks/challenge/challenge.mock.json'
 import { AuthService } from 'src/app/services/auth.service'
+import { ChallengeService } from 'src/app/services/challenge.service'
 
 describe('StarterComponent', () => {
   let component: StarterComponent
@@ -16,6 +17,8 @@ describe('StarterComponent', () => {
   let starterService: StarterService
   let authService: AuthService
   let authRoleSubject: BehaviorSubject<string>
+  let getUserBookmarksSpy: jasmine.Spy
+  let getUserFavoritesSpy: jasmine.Spy
 
   const mockChallenges$: Challenge[] = mockChallenges.map((challenge: any) => ({
     ...challenge,
@@ -36,6 +39,13 @@ describe('StarterComponent', () => {
       isUserLoggedIn: () => true,
       getUserId: () => of('mock-user-id')
     }
+    getUserBookmarksSpy = jasmine.createSpy().and.returnValue(of(['id-1', 'id-2']))
+    getUserFavoritesSpy = jasmine.createSpy().and.returnValue(of([]))
+
+    const challengeServiceMock = {
+      getUserBookmarks: getUserBookmarksSpy,
+      getUserFavorites: getUserFavoritesSpy
+    }
 
     TestBed.configureTestingModule({
       declarations: [StarterComponent],
@@ -43,6 +53,7 @@ describe('StarterComponent', () => {
       providers: [
         StarterService,
         { provide: AuthService, useValue: authServiceMock },
+        { provide: ChallengeService, useValue: challengeServiceMock },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting()
       ]
@@ -124,5 +135,14 @@ describe('StarterComponent', () => {
     component.ngOnDestroy()
 
     expect(component.userRoleSubs$.unsubscribe).toHaveBeenCalled()
+  })
+  it('should correctly determine if a challenge is bookmarked', () => {
+    component.bookmarkedChallenges = ['id-1', 'id-2']
+    expect(component.isBookmarkedChallenge('id-1')).toBeTruthy()
+    expect(component.isBookmarkedChallenge('id-3')).toBeFalsy()
+  })
+  it('should fetch and store bookmarks on init', () => {
+    expect(getUserBookmarksSpy).toHaveBeenCalled()
+    expect(component.bookmarkedChallenges).toEqual(['id-1', 'id-2'])
   })
 })

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -67,11 +67,6 @@ export class StarterComponent implements OnInit {
           this.challengeService.getUserBookmarks(userId).subscribe({
             next: (bookmarks: string[]) => {
               this.bookmarkedChallenges = bookmarks
-              // Marcar los retos como bookmarkeados
-              this.listChallenges.forEach(challenge => {
-                challenge.bookmarked = bookmarks.includes(challenge.id_challenge)
-              })
-              this.refreshChallengeList()
             },
             error: (err) => {
               console.error('Error getting bookmarks:', err)
@@ -92,6 +87,10 @@ export class StarterComponent implements OnInit {
   isFavoriteChallenge (challengeId: string): boolean {
     const result = this.favoriteChallenges.includes(challengeId)
     return result
+  }
+
+  isBookmarkedChallenge (challengeId: string): boolean {
+    return this.bookmarkedChallenges.includes(challengeId)
   }
 
   getChallenge (): void {

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -39,7 +39,8 @@ export class StarterComponent implements OnInit {
   isAdmin: boolean = false
   favoriteChallenges: string[] = []
   timesSolved: number = 0
-
+  bookmarkedChallenges: string[] = []
+  
   constructor (
     @Inject(StarterService) private readonly starterService: StarterService,
     @Inject(TranslateService) readonly translate: TranslateService,
@@ -61,6 +62,19 @@ export class StarterComponent implements OnInit {
             },
             error: (err) => {
               console.error('Error getting favorites:', err)
+            }
+          })
+          this.challengeService.getUserBookmarks(userId).subscribe({
+            next: (bookmarks: string[]) => {
+              this.bookmarkedChallenges = bookmarks
+              // Marcar los retos como bookmarkeados
+              this.listChallenges.forEach(challenge => {
+                challenge.bookmarked = bookmarks.includes(challenge.id_challenge)
+              })
+              this.refreshChallengeList()
+            },
+            error: (err) => {
+              console.error('Error getting bookmarks:', err)
             }
           })
         }

--- a/src/app/modules/starter/components/starter/starter.component.ts
+++ b/src/app/modules/starter/components/starter/starter.component.ts
@@ -40,7 +40,7 @@ export class StarterComponent implements OnInit {
   favoriteChallenges: string[] = []
   timesSolved: number = 0
   bookmarkedChallenges: string[] = []
-  
+
   constructor (
     @Inject(StarterService) private readonly starterService: StarterService,
     @Inject(TranslateService) readonly translate: TranslateService,

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -185,4 +185,20 @@ describe('ChallengeService', () => {
       })
     })
   })
+
+  it('should call getUserBookmarks() and return data', () => {
+    const userId = '123'
+    const mockBookmarks: string[] = ['challenge1', 'challenge2']
+    service.getUserBookmarks(userId).subscribe(bookmarks => {
+      expect(bookmarks).toEqual(mockBookmarks)
+    })
+
+    const req = httpMock.expectOne(
+      `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_USER_FAVORITES}/${userId}/bookmarks`
+    )
+    expect(req.request.method).toBe('GET')
+    expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token')
+
+    req.flush(mockBookmarks)
+  })
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -149,6 +149,15 @@ export class ChallengeService {
     return this.http.get<string[]>(url, { headers });
   }
 
+  getUserBookmarks (userId: string): Observable<string[]> {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    }
+    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_USER_FAVORITES}/${userId}/bookmarks`
+    return this.http.get<string[]>(url, { headers })
+  }
+
   addBookmark (challengeId: string): Observable<any> {
     const headers = {
       'Content-Type': 'application/json',

--- a/src/app/services/starter.service.spec.ts
+++ b/src/app/services/starter.service.spec.ts
@@ -38,7 +38,9 @@ describe('StarterService', () => {
       favorites_count: 0,
       saved_count: 0,
       timesFavorite: 0,
-      timesSolved: 0
+      timesSolved: 0,
+      bookmarked: false
+
     }))
   })
 

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -43,7 +43,9 @@
 
       <button class="stat d-flex align-items-center bookmark-button"
         [ngbTooltip]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)"
-        (click)="toggleBookmark($event)">
+        (click)="toggleBookmark($event)"
+        [attr.aria-label]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)"
+        [attr.aria-pressed]="isBookmarked">
         <div>
           <img *ngIf="!isBookmarked" src="assets/img/icon/bookmark.svg" [attr.alt]="'tooltips.bookmarks.unsaved' | translate">
           <img *ngIf="isBookmarked" src="assets/img/icon/bookmark-filled.svg" [attr.alt]="'tooltips.bookmarks.saved' | translate">


### PR DESCRIPTION
**This PR 432 is part of the User Story 390** → Como alumn@, puedo dar/quitar bookmark a un reto

-> **This branch has been created from branch 429**

 **What this PR does:**

- Shows which challenges the logged-in user has already bookmarked, both in the challenge list and detail page.
- Reuses the same logic pattern as the favorite functionality (isBookmarkedChallenge) for consistency.

**How to test it**

1. Log in as any user.
2. On the challenge list and on the challenge detail page, verify that the bookmark icon:
- Appears filled if the challenge is already bookmarked.
- Appears empty if it's not bookmarked.
- Clicking the icon should toggle it and reflect the correct state immediately.

**To consider:**

- Although we fetch the total number of bookmarks (timesBookmarked), it is not displayed correctly. 
- This count will be removed in a future PR.
- For now, only test the bookmark icon state (marked/unmarked) — not the count.
- I'll add the UI change in the changelog in my next PR. 

**About SonarCloud:**
This PR introduces logic that overlaps with existing code, slightly increasing code duplication. While the ideal solution would be to refactor this into a shared service (e.g., BookmarkService), this goes beyond the scope of the current PR and should be addressed in a follow-up task - **I've added it as a technical debt**