### PR TITLE
PR 3/3 - fix(bookmark): remove bookmark count (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - show times solved counter in the challenge list and detail (#389)
 - Submit solution and update solved counter (#389)
 - display user bookmarks on login (#432)
+- remove bookmark count (#431)
+
 
 ### [ita-challenges-frontend-3.1.34-RELEASE] - 2025-05-15 (feature#329)
 

--- a/src/app/models/challenge.model.ts
+++ b/src/app/models/challenge.model.ts
@@ -14,7 +14,6 @@ export class Challenge {
   detail: ChallengeDetails
   languages: Language[] = []
   solutions: Solution[] = []
-
   timesSolved: number
   bookmarked: boolean
 
@@ -27,11 +26,8 @@ export class Challenge {
     this.favorites_count = element.favorites_count || 0
     this.saved_count = element.saved_count || 0
     this.timesFavorite = element.timesFavorite || 0
-
     this.timesSolved = element.timesSolved || 0
-
     this.bookmarked = element.bookmarked || false
-
     this.detail = element.detail
 
     element.languages.forEach((language: Language) => {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -35,10 +35,10 @@
         <img src="assets/img/icon/bullseye.svg" alt="Bullseye">
         <span class="txt">{{timesSolved}}</span>
       </span>
+
       <span class="stat" [ngbTooltip]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)" (click)="toggleBookmark($event)" (keydown.enter)="toggleBookmark($event)" [attr.aria-pressed]="isBookmarked" [attr.aria-label]="isBookmarked ? ('tooltips.bookmarks.saved' | translate) : ('tooltips.bookmarks.unsaved' | translate)">
         <img *ngIf="!isBookmarked" src="assets/img/icon/bookmark.svg" [attr.alt]="'tooltips.bookmarks.unsaved' | translate">
         <img *ngIf=" isBookmarked" src="assets/img/icon/bookmark-filled.svg" [attr.alt]="'tooltips.bookmarks.saved' | translate">
-        <span class="txt">{{ bookmarks_count }}</span>
       </span>
       <span class="stat" [ngbTooltip]="'tooltips.favorites' | translate" (click)="toggleFavorite()" style="cursor: pointer;">
         <img *ngIf="!isFavorite" src="assets/img/icon/heart.svg" alt="Add to favorites">

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.spec.ts
@@ -134,26 +134,22 @@ describe('ChallengeHeaderComponent', () => {
 
   it('toggleBookmark: add bookmark when not bookmarked', done => {
     component.idChallenge = 'B1';
-    component.bookmarks_count = 0;
     component.isBookmarked = false;
     challengeService.addBookmark.mockReturnValue(of({ bookmarked: true, timesBookmarked: 1 }));
     component.toggleBookmark(new MouseEvent('click'));
     setTimeout(() => {
       expect(component.isBookmarked).toBe(true);
-      expect(component.bookmarks_count).toBe(1);
       done();
     });
   });
 
   it('toggleBookmark: remove bookmark when bookmarked', done => {
     component.idChallenge = 'B1';
-    component.bookmarks_count = 1;
     component.isBookmarked = true;
     challengeService.removeBookmark.mockReturnValue(of({ bookmarked: false, timesBookmarked: 0 }));
     component.toggleBookmark(new MouseEvent('click'));
     setTimeout(() => {
       expect(component.isBookmarked).toBe(false);
-      expect(component.bookmarks_count).toBe(0);
       done();
     });
   });

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -38,7 +38,6 @@ export class ChallengeHeaderComponent implements OnInit {
   @Input() favorites_count: number = 0
   @Input() isFavorite: boolean = false
   @Input() isBookmarked: boolean = false
-  @Input() bookmarks_count: number = 0
 
   @Input() timesSolved: number = 0
   @Output() startChallenge = new EventEmitter<boolean>()
@@ -200,7 +199,6 @@ export class ChallengeHeaderComponent implements OnInit {
       this.challengeService.removeBookmark(this.idChallenge).subscribe({
         next: response => {
           this.isBookmarked = response.bookmarked
-          this.bookmarks_count = response.timesBookmarked
         },
         error: error => {
           console.error('Error removing bookmark:', error)
@@ -210,7 +208,6 @@ export class ChallengeHeaderComponent implements OnInit {
       this.challengeService.addBookmark(this.idChallenge).subscribe({
         next: response => {
           this.isBookmarked = response.bookmarked
-          this.bookmarks_count = response.timesBookmarked
         },
         error: error => {
           console.error('Error adding bookmark:', error)

--- a/src/app/shared/components/challenge-card/challenge-card.component.html
+++ b/src/app/shared/components/challenge-card/challenge-card.component.html
@@ -50,7 +50,6 @@
           <img *ngIf="!isBookmarked" src="assets/img/icon/bookmark.svg" [attr.alt]="'tooltips.bookmarks.unsaved' | translate">
           <img *ngIf="isBookmarked" src="assets/img/icon/bookmark-filled.svg" [attr.alt]="'tooltips.bookmarks.saved' | translate">
         </div>
-        <div class="txt">{{bookmarks_count}}</div>
       </button>
 
       <button class="stat d-flex align-items-center favorite-button"

--- a/src/app/shared/components/challenge-card/challenge-card.component.spec.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.spec.ts
@@ -138,14 +138,12 @@ describe('ChallengeCardComponent', () => {
   it('toggleBookmark: should call addBookmark when not bookmarked', done => {
     component.id = 'C2'
     component.isBookmarked = false
-    component.bookmarks_count = 0
     mockChallengeService.addBookmark.mockReturnValue(of({ bookmarked: true, timesBookmarked: 1 }))
 
     component.toggleBookmark(new MouseEvent('click'))
     setTimeout(() => {
       expect(mockChallengeService.addBookmark).toHaveBeenCalledWith('C2')
       expect(component.isBookmarked).toBe(true)
-      expect(component.bookmarks_count).toBe(1)
       done()
     })
   })
@@ -153,14 +151,12 @@ describe('ChallengeCardComponent', () => {
   it('toggleBookmark: should call removeBookmark when already bookmarked', done => {
     component.id = 'C2'
     component.isBookmarked = true
-    component.bookmarks_count = 1
     mockChallengeService.removeBookmark.mockReturnValue(of({ bookmarked: false, timesBookmarked: 0 }))
 
     component.toggleBookmark(new MouseEvent('click'))
     setTimeout(() => {
       expect(mockChallengeService.removeBookmark).toHaveBeenCalledWith('C2')
       expect(component.isBookmarked).toBe(false)
-      expect(component.bookmarks_count).toBe(0)
       done()
     })
   })

--- a/src/app/shared/components/challenge-card/challenge-card.component.ts
+++ b/src/app/shared/components/challenge-card/challenge-card.component.ts
@@ -70,7 +70,6 @@ export class ChallengeCardComponent {
       this.challengeService.removeBookmark(this.id).subscribe({
         next: response => {
           this.isBookmarked = response.bookmarked
-          this.bookmarks_count = response.timesBookmarked
         },
         error: error => {
           console.error('Error removing bookmark:', error)
@@ -80,7 +79,6 @@ export class ChallengeCardComponent {
       this.challengeService.addBookmark(this.id).subscribe({
         next: response => {
           this.isBookmarked = response.bookmarked
-          this.bookmarks_count = response.timesBookmarked
         },
         error: error => {
           console.error('Error adding bookmark:', error)


### PR DESCRIPTION
**This PR 431 is part of the User Story 390 → Como alumn@, puedo dar/quitar bookmark a un reto**

**-> This branch was created from feature/432-show-user-bookmarks.**

**What this PR does:**
- Removes the display of the bookmark counter (bookmarks_count) in the UI.
- Updates the components (ChallengeCardComponent, ChallengeHeaderComponent) and their related tests to eliminate all usage of the timesBookmarked value.
- Focuses the logic solely on whether the challenge is bookmarked or not — not how many times.

![image](https://github.com/user-attachments/assets/888579c6-9c22-4064-a4fd-bd3a0590f2cc)

**How to test it:**

1. Log in as any user.
2. Go to any challenge list or challenge detail page.
3. Confirm that the bookmark icon is shown, but there is no numerical counter next to it.
4. The icon still correctly shows bookmarked/not bookmarked status and toggles as expected.

**To consider:**
- This change has no impact on backend logic — only the front-end display has been modified.
- Since there’s no backend endpoint for timesBookmarked, this data was unnecessary and is now removed.

