### PR TITLE
Secure createChallenge endpoint by adding auth token to request headers

### DIFF
--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -94,11 +94,11 @@ export class ChallengeService {
 
   createChallenge (challenge: CreateChallenge): Observable<any> {
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_CHALLENGES_URL}`
-    return this.http.post(url, challenge, {
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    })
+    const headers = {
+      'Content-Type': 'application/json',
+      ...this.authService.getAuthHeaders()
+    };
+    return this.http.post(url, challenge, { headers });
   }
 
   addToFavorites (challengeId: string): Observable<FavoriteResponse> {


### PR DESCRIPTION
**This PR adds security to the createChallenge endpoint by including the authentication token in the HTTP headers.** 