### PR TITLE
2/3 - feat(tags-loading): update service and component to fetch tags by language (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to
 
 - Configuration for SonarCloud compatibility: added sonar-project.properties with coverage paths and exclusions (#493)
 - Fixed missing braces in en.json and es.json (#492)
+- Refactored challenge-form service and component to load tags based on selected language (#470)
 
 ### [ita-challenges-frontend-3.1.35-RELEASE] - 2025-05-28
 

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.html
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.html
@@ -150,7 +150,7 @@
               </div>
             </div>
           </div>
-
+          @if (currentTags.length > 0) {
           <div class="form-group mb-4">
             <label class="form-label">Tags</label>
             <div class="tags-group">
@@ -166,6 +166,7 @@
               }
             </div>
           </div>
+          }
         </div>
       </form>
     </div>

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
@@ -284,13 +284,12 @@ describe('ChallengeFormComponent', () => {
   })
 
   it('should update selectedLanguageId and load tags when language changes', () => {
-    const mockLoadTags = jest.spyOn(component, 'loadTags') // Mockear la función de carga
+    const mockLoadTags = jest.spyOn(component, 'loadTags')
     component.onLanguageChange('Javascript')
     expect(component.selectedLanguageId).toBe('09fabe32-7362-4bfb-ac05-b7bf854c6e0f')
-    expect(mockLoadTags).toHaveBeenCalled() // Verificar que carga los tags
+    expect(mockLoadTags).toHaveBeenCalled()
   })
 
-  // ✅ Test para `loadTags()`
   it('should call getTagsByLanguage() with the correct language ID', () => {
     component.selectedLanguageId = '09fabe32-7362-4bfb-ac05-b7bf854c6e0f'
     component.loadTags()
@@ -300,10 +299,10 @@ describe('ChallengeFormComponent', () => {
   it('should not call getTagsByLanguage() if selectedLanguageId is empty', () => {
     const spyGetTags = jest.spyOn(mockChallengeFormService, 'getTagsByLanguage')
 
-    component.selectedLanguageId = '' // Simulamos que no hay un lenguaje seleccionado
+    component.selectedLanguageId = ''
     component.loadTags()
 
-    expect(spyGetTags).not.toHaveBeenCalled() // ✅ Verificamos que no intenta cargar tags
+    expect(spyGetTags).not.toHaveBeenCalled()
   })
 
   it('should handle errors when calling getTagsByLanguage()', () => {
@@ -321,7 +320,7 @@ describe('ChallengeFormComponent', () => {
     expect(component.currentTags).toEqual([])
     expect(component.selectedTags).toEqual([])
 
-    expect(consoleSpy).toHaveBeenCalledWith('Error al obtener las etiquetas:', expect.any(Error))
+    expect(consoleSpy).toHaveBeenCalledWith('Error fetching tags:', expect.any(Error))
 
     consoleSpy.mockRestore()
   })

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
@@ -4,7 +4,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { FormsModule } from '@angular/forms'
 import { CommonModule } from '@angular/common'
 import { Router } from '@angular/router'
-import { of } from 'rxjs'
+import { of, throwError } from 'rxjs'
 import { ChallengeFormService } from 'src/app/services/challenge-form.service'
 import { ChallengeService } from 'src/app/services/challenge.service'
 import { EditorModule } from '@tinymce/tinymce-angular'
@@ -103,15 +103,15 @@ describe('ChallengeFormComponent', () => {
     mockChallengeFormService = {
       getAllLangugesCreateForm: jest.fn().mockReturnValue(of({
         results: [
-          { language_name: 'Javascript', id_language: 1 },
-          { language_name: 'Java', id_language: 2 },
+          { language_name: 'Javascript', id_language: '09fabe32-7362-4bfb-ac05-b7bf854c6e0f' },
+          { language_name: 'Java', id_language: '660e1b18-0c0a-4262-a28a-85de9df6ac5f' },
           { language_name: 'Python', id_language: 3 },
           { language_name: 'PHP', id_language: 4 },
           { language_name: 'Typescript', id_language: 5 },
           { language_name: 'SQL', id_language: 6 }
         ]
       })),
-      getTags: jest.fn().mockReturnValue(of(mockJavascriptTags))
+      getTagsByLanguage: jest.fn().mockReturnValue(of(mockJavascriptTags))
     } as unknown as jest.Mocked<ChallengeFormService>
 
     mockChallengeService = {
@@ -283,9 +283,54 @@ describe('ChallengeFormComponent', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/ita-challenge/challenges'])
   })
 
+  it('should update selectedLanguageId and load tags when language changes', () => {
+    const mockLoadTags = jest.spyOn(component, 'loadTags') // Mockear la función de carga
+    component.onLanguageChange('Javascript')
+    expect(component.selectedLanguageId).toBe('09fabe32-7362-4bfb-ac05-b7bf854c6e0f')
+    expect(mockLoadTags).toHaveBeenCalled() // Verificar que carga los tags
+  })
+
+  // ✅ Test para `loadTags()`
+  it('should call getTagsByLanguage() with the correct language ID', () => {
+    component.selectedLanguageId = '09fabe32-7362-4bfb-ac05-b7bf854c6e0f'
+    component.loadTags()
+    expect(mockChallengeFormService.getTagsByLanguage).toHaveBeenCalledWith('09fabe32-7362-4bfb-ac05-b7bf854c6e0f')
+  })
+
+  it('should not call getTagsByLanguage() if selectedLanguageId is empty', () => {
+    const spyGetTags = jest.spyOn(mockChallengeFormService, 'getTagsByLanguage')
+
+    component.selectedLanguageId = '' // Simulamos que no hay un lenguaje seleccionado
+    component.loadTags()
+
+    expect(spyGetTags).not.toHaveBeenCalled() // ✅ Verificamos que no intenta cargar tags
+  })
+
+  it('should handle errors when calling getTagsByLanguage()', () => {
+    jest.spyOn(mockChallengeFormService, 'getTagsByLanguage').mockReturnValue(
+      throwError(() => new Error('Error de carga'))
+    )
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    component.selectedLanguageId = '09fabe32-7362-4bfb-ac05-b7bf854c6e0f'
+    component.loadTags()
+
+    expect(mockChallengeFormService.getTagsByLanguage).toHaveBeenCalledWith(component.selectedLanguageId)
+
+    expect(component.currentTags).toEqual([])
+    expect(component.selectedTags).toEqual([])
+
+    expect(consoleSpy).toHaveBeenCalledWith('Error al obtener las etiquetas:', expect.any(Error))
+
+    consoleSpy.mockRestore()
+  })
+
   describe('Tag Management', () => {
     it('should load tags on component initialization', () => {
-      expect(mockChallengeFormService.getTags).toHaveBeenCalled()
+      component.selectedLanguageId = '09fabe32-7362-4bfb-ac05-b7bf854c6e0f'
+      component.loadTags()
+      expect(mockChallengeFormService.getTagsByLanguage).toHaveBeenCalledWith('09fabe32-7362-4bfb-ac05-b7bf854c6e0f')
       expect(component.currentTags).toEqual(mockJavascriptTags.results)
     })
 

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -77,7 +77,6 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
     @Inject(TranslateService) readonly translate: TranslateService
   ) {
     this.loadLanguages()
-    this.loadTags()
     translate.addLangs(['en', 'es', 'ca'])
     translate.setDefaultLang('es')
     translate.use('es')

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -183,10 +183,13 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
   }
 
   loadTags (): void {
+    if (this.selectedLanguageId.length === 0) {
+      console.warn('No language selected, skipping tag loading.')
+      return
+    }
     this.challengeFormService.getTagsByLanguage(this.selectedLanguageId).subscribe({
       next: (response: TagResponse) => {
         this.currentTags = response.results ?? []
-
         this.selectedTags = []
       },
       error: (error) => {

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -44,6 +44,7 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
   }
 
   languages: Language[] = []
+  selectedLanguageId: string = ''
   selectedTags: string[] = []
   currentTags: any[] = []
 
@@ -158,6 +159,10 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
 
   onLanguageChange (language: string): void {
     this.challenge.language = language
+    const selectedLang = this.languages.find(lang => lang.language_name === language)
+    this.selectedLanguageId = (selectedLang != null) ? selectedLang.id_language : ''
+    // Cargar los tags con el nuevo ID del lenguaje
+    this.loadTags()
     /* istanbul ignore next */
     // Actualiza CodeMirror con el nuevo lenguaje
     if (this.editor != null) {
@@ -178,7 +183,7 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
   }
 
   loadTags (): void {
-    this.challengeFormService.getTags().subscribe({
+    this.challengeFormService.getTagsByLanguage(this.selectedLanguageId).subscribe({
       next: (response: TagResponse) => {
         this.currentTags = response.results ?? []
 

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -160,7 +160,6 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
     this.challenge.language = language
     const selectedLang = this.languages.find(lang => lang.language_name === language)
     this.selectedLanguageId = (selectedLang != null) ? selectedLang.id_language : ''
-    // Cargar los tags con el nuevo ID del lenguaje
     this.loadTags()
     /* istanbul ignore next */
     // Actualiza CodeMirror con el nuevo lenguaje
@@ -183,7 +182,6 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
 
   loadTags (): void {
     if (this.selectedLanguageId.length === 0) {
-      console.warn('No language selected, skipping tag loading.')
       return
     }
     this.challengeFormService.getTagsByLanguage(this.selectedLanguageId).subscribe({
@@ -192,7 +190,7 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
         this.selectedTags = []
       },
       error: (error) => {
-        console.error('Error al obtener las etiquetas:', error)
+        console.error('Error fetching tags:', error)
         this.currentTags = []
         this.selectedTags = []
       }

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -208,7 +208,6 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
       this.challenge.challengeTitle.trim() !== '' &&
       this.challenge.description.trim() !== '' &&
       isLanguageValid &&
-      isLanguageValid &&
       this.challenge.solution.trim() !== ''
     )
   }

--- a/src/app/services/challenge-form.service.spec.ts
+++ b/src/app/services/challenge-form.service.spec.ts
@@ -41,4 +41,31 @@ describe('ChallengeFormService', () => {
 
     httpMock.expectOne(`${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ALL_LANGUAGE_URL}`).error(new ProgressEvent('error'));
   });
-});
+
+  it('should fetch tags by language', () => {
+    const mockTagsResponse = {
+      results: [{ id_tag: '1', tag_name: 'Frontend' }, { id_tag: '2', tag_name: 'Backend' }]
+    }
+
+    const languageId = 'javascript'
+
+    service.getTagsByLanguage(languageId).subscribe((res) => {
+      expect(res).toEqual(mockTagsResponse)
+    })
+
+    const req = httpMock.expectOne(`../assets/dummy/tags-${languageId}.json`)
+    expect(req.request.method).toBe('GET')
+    req.flush(mockTagsResponse)
+  })
+
+  it('should handle error when fetching tags by language', () => {
+    const languageId = 'javascript'
+
+    service.getTagsByLanguage(languageId).subscribe({
+      next: () => fail('Expected error'),
+      error: (err) => { expect(err).toBeTruthy() }
+    })
+
+    httpMock.expectOne(`../assets/dummy/tags-${languageId}.json`).error(new ProgressEvent('error'))
+  })
+})

--- a/src/app/services/challenge-form.service.ts
+++ b/src/app/services/challenge-form.service.ts
@@ -20,14 +20,6 @@ export class ChallengeFormService {
     return this.http.get<{ results: Language[] }>(url, { headers })
   }
 
-  getTags (): Observable<TagResponse> {
-    const headers = new HttpHeaders({
-      'Content-Type': 'application/json'
-    })
-    const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_CHALLENGE_TAGS}`
-    return this.http.get<TagResponse>(url, { headers })
-  }
-
   getTagsByLanguage (languageId: string): Observable<TagResponse> {
     const headers = new HttpHeaders({
       'Content-Type': 'application/json'

--- a/src/app/services/challenge-form.service.ts
+++ b/src/app/services/challenge-form.service.ts
@@ -27,4 +27,12 @@ export class ChallengeFormService {
     const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}${environment.BACKEND_ITA_CHALLENGE_TAGS}`
     return this.http.get<TagResponse>(url, { headers })
   }
+
+  getTagsByLanguage (languageId: string): Observable<TagResponse> {
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json'
+    })
+    const url = `../assets/dummy/tags-${languageId}.json`
+    return this.http.get<TagResponse>(url, { headers })
+  }
 }

--- a/src/app/services/challenge-form.service.ts
+++ b/src/app/services/challenge-form.service.ts
@@ -24,7 +24,7 @@ export class ChallengeFormService {
     const headers = new HttpHeaders({
       'Content-Type': 'application/json'
     })
-    const url = `../assets/dummy/tags-${languageId}.json`
+    const url = `../assets/dummy/tags-${languageId}.json` // Temporary mock data — replace with real API endpoint when available
     return this.http.get<TagResponse>(url, { headers })
   }
 }


### PR DESCRIPTION
This PR completes **task 470**, part of **user story 459** — "As a mentor, I want to be able to see tags by category."
 
# **Show Tags Based on Selected Language**  

### **Changes included:**  
- **Refactored service to use `getTagsByLanguage(languageId)`**, removing the previous generic `getTags()` function.  
- **Updated component logic** to ensure tags are loaded only when a language is selected, preventing unnecessary API calls.  
- **Updated unit tests** to cover the new functionality, including error cases and validation for tag loading.  

### Modified Files:
- src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
- src/app/modules/challenge/components/challenge-form/challenge-form.component.html
- src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
- src/app/services/challenge-form.service.ts
- src/app/services/challenge-form.service.spec.ts
-  CHANGELOG.md

###  Steps to Test the PR
1️⃣ **Log in as an administrator and create a new challenge.**  
2️⃣ **Verify that tags are not displayed initially.**  
3️⃣ **Select a language (JavaScript or Java, the only ones with mock data).**  
4️⃣ **Confirm that after selecting a language, the corresponding tags are displayed.**  
🔹 **This flow ensures that tags are loaded only upon language selection, aligning with the implemented logic in the PR.**


## ✅ PR Author Self-check  

- [x] I tested my changes locally and verified they work as expected.  
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor).  
- [x] Title, description, and changelog (if needed) are filled in correctly.  
- [x] There are no leftover merge conflicts or unrelated changes from previous branches.  
- [x] All automated checks (like SonarCloud) have passed.  
- [x] I responded to all previous review comments and only resolved those I truly addressed.  