### PR TITLE
fix(sonar-project): enable JS coverage and exclude spec files (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [ita-challenges-frontend-3.1.36-RELEASE] - 2025-06-10
+
+- Configuration for SonarCloud compatibility: added sonar-project.properties with coverage paths and exclusions (#493)
+
 ### [ita-challenges-frontend-3.1.35-RELEASE] - 2025-05-28
 
 - [Added] 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,5 @@
 sonar.projectKey=IT-Academy-BCN_ita-challenges-frontend
 sonar.organization=it-academy-bcn
 sonar.host.url=https://sonarcloud.io
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.coverage.exclusions=**/*.spec.ts


### PR DESCRIPTION
Added 'sonar.javascript.lcov.reportPaths=coverage/lcov.info' 
and 'sonar.coverage.exclusions=*/.spec.ts' to ensure SonarQube processes coverage data correctly.

## ✅ PR Author Self-check  

- [x] I tested my changes locally and verified they work as expected.  
- [x] The PR has a clear and focused purpose (only one feature, fix or refactor).  
- [x] Title, description, and changelog (if needed) are filled in correctly.  
- [x] There are no leftover merge conflicts or unrelated changes from previous branches.  
- [x] All automated checks (like SonarCloud) have passed.  
- [x] I responded to all previous review comments and only resolved those I truly addressed.  