### PR TITLE
Feature(edit-challenge-service): Create a service that connects the endpoint to edit the challenge (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to
 ### [ita-challenges-frontend-4.0.0-RELEASE] - 2025-09-15
 
 ### Added
-- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#a modificar]).
+- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#689]).
 
 ### [ita-challenges-frontend-3.3.2-RELEASE] - 2025-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [ita-challenges-frontend-4.0.0-RELEASE] - 2025-09-15
+
+### Added
+- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#a modificar]).
+
 ### [ita-challenges-frontend-3.3.2-RELEASE] - 2025-07-30
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "3.3.2-RELEASE",
+  "version": "4.0.0-RELEASE",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ita-challenges-frontend",
-      "version": "3.3.2-RELEASE",
+      "version": "4.0.0-RELEASE",
       "dependencies": {
         "@angular/compiler": "^18.0.2",
         "@angular/core": "^18.2.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "3.3.2-RELEASE",
+  "version": "4.0.0-RELEASE",
    "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.dev.json",

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -222,22 +222,22 @@ describe('ChallengeService', () => {
     ];
 
     it('should fetch related challenges successfully', () => {
-      // Act
+      
       service.getRelatedChallenges(mockChallengeId).subscribe(challenges => {
-        // Assert
+       
         expect(challenges).toEqual(mockChallenges);
       });
 
-      // Arrange
+  
       const expectedUrl = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${mockChallengeId}/related`;
       const req = httpMock.expectOne(expectedUrl);
       
-      // Assert request
+      
       expect(req.request.method).toBe('GET');
       expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
       expect(req.request.headers.get('Content-Type')).toBe('application/json');
 
-      // Respond with mock data
+      
       req.flush({ results: mockChallenges });
     });
 
@@ -258,7 +258,7 @@ describe('ChallengeService', () => {
         statusText: 'Not Found'
       });
 
-      // Spy on console.error to verify it's called
+      
       jest.spyOn(console, 'error').mockImplementation(() => {});
 
       service.getRelatedChallenges(mockChallengeId).subscribe({
@@ -285,6 +285,48 @@ describe('ChallengeService', () => {
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${invalidId}/related`
       );
       req.flush({ results: mockChallenges });
+    });
+  });
+
+  describe('editChallenge', () => {
+    const mockChallengeId = '12345';
+    const mockChallengeData = { challenge_title: 'Updated Challenge Title' };
+    const mockSuccessResponse = { message: 'Challenge updated successfully' };
+
+    it('should update a challenge successfully', () => {
+      service.editChallenge(mockChallengeId, mockChallengeData).subscribe(response => {
+        expect(response).toEqual(mockSuccessResponse);
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${mockChallengeId}/update`
+      );
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
+      expect(req.request.body).toEqual(mockChallengeData);
+      req.flush(mockSuccessResponse);
+    });
+
+    it('should handle HTTP errors on update', () => {
+      const mockError = new HttpErrorResponse({
+        status: 500,
+        statusText: 'Internal Server Error'
+      });
+
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      service.editChallenge(mockChallengeId, mockChallengeData).subscribe({
+        next: () => fail('should have failed with 500 error'),
+        error: (error) => {
+          expect(error.status).toEqual(500);
+          expect(console.error).toHaveBeenCalledWith('Error updating challenge:', mockError);
+        }
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${mockChallengeId}/update`
+      );
+      req.flush(null, mockError);
     });
   });
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -218,5 +218,21 @@ export class ChallengeService {
   );
 }
 
+editChallenge(challengeId: string, challenge: Partial<Challenge>): Observable<any> {
+  const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${challengeId}/update`;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...this.authService.getAuthHeaders() 
+  };
+
+  return this.http.put<any>(url, challenge, { headers }).pipe(
+    map(response => response),
+    catchError((error: HttpErrorResponse) => {
+      console.error('Error updating challenge:', error);
+      return throwError(() => error);
+    })
+  );
+}
 
 }


### PR DESCRIPTION
## Title
feat: add service to update and persist challenges via endpoint. This task belongs to user story #572

---

## Description
This PR connects to the existing challenge endpoint and enables updating and persisting a challenge in the database.  

> **Note:** This implementation only includes the service required for users to modify a challenge through the interface.

### Included in this PR
- Connection to the existing challenge endpoint.  
- Creation of a new service to update and save challenges.  
- Unit tests for the newly created service.  
---
##Summary Changed Archives
-Challenge.service.ts (added a new service to connect to the endpoint)
-Challenge.service.spec.ts (added tests for the service)
---

<img width="978" height="352" alt="Captura de pantalla 2025-09-15 133418" src="https://github.com/user-attachments/assets/a193ba8a-1b2f-4ba1-9a41-243efdb924e5" />

## Testing Instructions
To run the tests, execute the following command in the console:  
```bash
npm run test







