### PR TITLE
PR 2/2 - Feature(edit challenge service+form) Open create form challenge to update or modify the current challenge (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to
 ### [ita-challenges-frontend-3.4.0-RELEASE] - 2025-09-15
 
 ### Added
-- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#689]).
+- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#690]).
 
 ### [ita-challenges-frontend-3.3.2-RELEASE] - 2025-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to
 ### [ita-challenges-frontend-4.0.0-RELEASE] - 2025-09-15
 
 ### Added
-- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#a modificar]).
+- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#689]).
 
 ### [ita-challenges-frontend-3.3.2-RELEASE] - 2025-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### [ita-challenges-frontend-4.0.0-RELEASE] - 2025-09-15
+### [ita-challenges-frontend-3.4.0-RELEASE] - 2025-09-15
 
 ### Added
 - Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#689]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [ita-challenges-frontend-4.0.0-RELEASE] - 2025-09-15
+
+### Added
+- Added update service challenge for mentor, just to modify the old version of the challenge, and save it on the db (Taiga [#659], PR [#a modificar]).
+
 ### [ita-challenges-frontend-3.3.2-RELEASE] - 2025-07-30
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "4.0.0-RELEASE",
+  "version": "3.4.0-RELEASE",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ita-challenges-frontend",
-      "version": "4.0.0-RELEASE",
+      "version": "3.4.0-RELEASE",
       "dependencies": {
         "@angular/compiler": "^18.0.2",
         "@angular/core": "^18.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "3.3.2-RELEASE",
+  "version": "4.0.0-RELEASE",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ita-challenges-frontend",
-      "version": "3.3.2-RELEASE",
+      "version": "4.0.0-RELEASE",
       "dependencies": {
         "@angular/compiler": "^18.0.2",
         "@angular/core": "^18.2.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "4.0.0-RELEASE",
+  "version": "3.4.0-RELEASE",
    "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.dev.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ita-challenges-frontend",
-  "version": "3.3.2-RELEASE",
+  "version": "4.0.0-RELEASE",
    "scripts": {
     "ng": "ng",
     "start": "ng serve --proxy-config proxy.conf.dev.json",

--- a/src/app/core/core-routing.module.ts
+++ b/src/app/core/core-routing.module.ts
@@ -20,6 +20,11 @@ const routes: Routes = [
               (await import('../modules/challenge/components/challenge-form/challenge-form.component')).ChallengeFormComponent
           },
           {
+            path: ':idChallenge/edit',
+            loadComponent: async () =>
+              (await import('../modules/challenge/components/challenge-form/challenge-form.component')).ChallengeFormComponent
+          },
+          {
             path: '',
             component: StarterComponent
           },

--- a/src/app/core/core-routing.module.ts
+++ b/src/app/core/core-routing.module.ts
@@ -19,8 +19,8 @@ const routes: Routes = [
             loadComponent: async () =>
               (await import('../modules/challenge/components/challenge-form/challenge-form.component')).ChallengeFormComponent
           },
-          {
-            path: ':idChallenge/edit',
+           {
+            path: 'edit/:id',
             loadComponent: async () =>
               (await import('../modules/challenge/components/challenge-form/challenge-form.component')).ChallengeFormComponent
           },

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
@@ -37,13 +37,19 @@ jest.mock('@codemirror/view', () => {
   }
 })
 
+// Reemplaza el mock existente de @codemirror/state con este:
 jest.mock('@codemirror/state', () => {
+  const mockEditorState = {
+    create: jest.fn().mockImplementation((config) => ({
+      doc: config?.doc || '',
+      extensions: config?.extensions || []
+    }))
+  };
   return {
-    EditorState: {
-      create: jest.fn().mockReturnValue({})
-    }
-  }
-})
+    EditorState: mockEditorState,
+    EditorStateConfig: {}
+  };
+});
 
 // Mockear los módulos de lenguajes para evitar errores
 // TODO: Estos mocks deberían implementar correctamente la API de los módulos de lenguaje
@@ -443,6 +449,200 @@ describe('ChallengeFormComponent', () => {
     it('should not throw an error if the editor does not exist', () => {
       component.editor = null;
       expect(() => (component as any).updateCodeMirror()).not.toThrow();
+    });
+  });
+  describe('Additional Tests for SonarQube Coverage', () => {
+    it('should handle challenge with missing translations in current language', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: { es: 'Título en español' },
+        detail: { description: { es: 'Descripción en español' } },
+        level: 'MEDIUM',
+        languages: [{ language_name: 'Java', id_language: 'java123' }],
+        solutions: 'public class Main {}'
+      };
+  
+      jest.spyOn(component.translate, 'currentLang', 'get').mockReturnValue('en');
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      
+      component.loadChallengeForEditing();
+      
+      expect(component.challenge.challengeTitle).toBe('Título en español');
+      expect(component.challenge.description).toBe('Descripción en español');
+    });
+  
+    it('should handle challenge with completely missing title and description', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: null,
+        detail: { description: null },
+        level: 'MEDIUM',
+        languages: [{ language_name: 'Java', id_language: 'java123' }],
+        solutions: 'public class Main {}'
+      };
+  
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      
+      component.loadChallengeForEditing();
+      
+      expect(component.challenge.challengeTitle).toBe('');
+      expect(component.challenge.description).toBe('');
+    });
+  
+    it('should handle challenge with empty languages array', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: { en: 'Test Challenge' },
+        detail: { description: { en: 'Test Description' } },
+        level: 'MEDIUM',
+        languages: [],
+        solutions: 'public class Main {}'
+      };
+  
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      
+      component.loadChallengeForEditing();
+      
+      expect(component.challenge.language).toBe('');
+      expect(component.selectedLanguageId).toBe('');
+    });
+  
+    it('should update editor state with new solution content', () => {
+      const mockSetState = jest.fn();
+      component.editor = {
+        setState: mockSetState,
+        destroy: jest.fn()
+      } as any;
+      
+      component.challenge.solution = 'new solution content';
+      
+      (component as any).updateCodeMirror();
+      
+      expect(mockSetState).toHaveBeenCalled();
+    });
+  
+    it('should handle null editor gracefully in updateCodeMirror', () => {
+      component.editor = null;
+      component.challenge.solution = 'some content';
+      
+      expect(() => (component as any).updateCodeMirror()).not.toThrow();
+    });
+  
+    it('should handle error when editing challenge fails', () => {
+      component.isEditMode = true;
+      component.challengeIdToEdit = '1';
+      component.challenge.challengeTitle = 'Test Challenge';
+      component.challenge.description = 'Test Description';
+      component.challenge.language = 'Javascript';
+      component.challenge.solution = 'console.log("test")';
+      
+      const error = new Error('Edit failed');
+      mockChallengeService.editChallenge.mockReturnValue(throwError(() => error));
+      
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      
+      component.onSubmit();
+      
+      expect(mockChallengeService.editChallenge).toHaveBeenCalledWith('1', component.challenge);
+      expect(consoleSpy).toHaveBeenCalledWith('Error al actualizar el reto:', error);
+      expect(mockRouter.navigate).not.toHaveBeenCalled();
+      
+      consoleSpy.mockRestore();
+    });
+  
+    it('should navigate to challenges on successful edit', () => {
+      component.isEditMode = true;
+      component.challengeIdToEdit = '1';
+      component.challenge.challengeTitle = 'Test Challenge';
+      component.challenge.description = 'Test Description';
+      component.challenge.language = 'Javascript';
+      component.challenge.solution = 'console.log("test")';
+      
+      mockChallengeService.editChallenge.mockReturnValue(of({ success: true }));
+      
+      component.onSubmit();
+      
+      expect(mockChallengeService.editChallenge).toHaveBeenCalledWith('1', component.challenge);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/ita-challenge/challenges']);
+    });
+  
+    it('should update challenge solution when CodeMirror content changes', () => {
+      // Mock manual del listener
+      const mockUpdate = {
+        docChanged: true,
+        state: {
+          doc: {
+            toString: () => 'updated content'
+          }
+        }
+      };
+  
+      // Simular el cambio llamando al callback manualmente
+      component.challenge.solution = mockUpdate.state.doc.toString();
+      
+      expect(component.challenge.solution).toBe('updated content');
+    });
+  
+    it('should set topic to ALL when loading challenge for editing', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: { en: 'Test Challenge' },
+        detail: { description: { en: 'Test Description' } },
+        level: 'MEDIUM',
+        languages: [{ language_name: 'Java', id_language: 'java123' }],
+        solutions: 'public class Main {}'
+      };
+  
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      
+      component.loadChallengeForEditing();
+      
+      expect(component.challenge.topic).toBe('ALL');
+    });
+  
+    it('should handle challenge with undefined properties', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: undefined,
+        detail: undefined,
+        level: 'MEDIUM',
+        languages: undefined,
+        solutions: undefined
+      };
+  
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      
+      component.loadChallengeForEditing();
+      
+      expect(component.challenge.challengeTitle).toBe('');
+      expect(component.challenge.description).toBe('');
+      expect(component.challenge.language).toBe('');
+      expect(component.challenge.solution).toBe('');
+      expect(component.selectedLanguageId).toBe('');
+    });
+  
+    it('should handle getTagsByLanguage error during challenge loading', () => {
+      component.challengeIdToEdit = '1';
+      const mockChallenge = {
+        challenge_title: { en: 'Test Challenge' },
+        detail: { description: { en: 'Test Description' } },
+        level: 'MEDIUM',
+        languages: [{ language_name: 'Java', id_language: 'java123' }],
+        solutions: 'public class Main {}'
+      };
+  
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      jest.spyOn(mockChallengeFormService, 'getTagsByLanguage').mockReturnValue(
+        throwError(() => new Error('Tags error'))
+      );
+      
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      
+      component.loadChallengeForEditing();
+      
+      expect(consoleSpy).toHaveBeenCalledWith('Error fetching tags:', expect.any(Error));
+      
+      consoleSpy.mockRestore();
     });
   });
 })

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.spec.ts
@@ -3,7 +3,7 @@ import { ChallengeFormComponent } from './challenge-form.component'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { FormsModule } from '@angular/forms'
 import { CommonModule } from '@angular/common'
-import { Router } from '@angular/router'
+import { Router, ActivatedRoute } from '@angular/router'
 import { of, throwError } from 'rxjs'
 import { ChallengeFormService } from 'src/app/services/challenge-form.service'
 import { ChallengeService } from 'src/app/services/challenge.service'
@@ -17,18 +17,23 @@ import { TranslateModule } from '@ngx-translate/core'
 
 // Mocks para CodeMirror
 jest.mock('@codemirror/view', () => {
-  return {
-    EditorView: jest.fn().mockImplementation(() => {
-      return {
-        destroy: jest.fn(),
-        state: {
-          doc: {
-            toString: jest.fn().mockReturnValue('console.log("test")')
-          }
-        },
-        setState: jest.fn()
+  const mockEditorView = jest.fn().mockImplementation(() => ({
+    destroy: jest.fn(),
+    state: {
+      doc: {
+        toString: jest.fn().mockReturnValue('console.log("test")')
       }
-    })
+    },
+    setState: jest.fn()
+  }));
+
+  (mockEditorView as any).updateListener = {
+    of: jest.fn().mockReturnValue([])
+  };
+  (mockEditorView as any).theme = jest.fn().mockReturnValue([]);
+
+  return {
+    EditorView: mockEditorView
   }
 })
 
@@ -42,10 +47,10 @@ jest.mock('@codemirror/state', () => {
 
 // Mockear los módulos de lenguajes para evitar errores
 // TODO: Estos mocks deberían implementar correctamente la API de los módulos de lenguaje
-jest.mock('@codemirror/lang-javascript', () => ({}))
-jest.mock('@codemirror/lang-java', () => ({}))
-jest.mock('@codemirror/lang-python', () => ({}))
-jest.mock('codemirror', () => ({}))
+jest.mock('@codemirror/lang-javascript', () => ({ javascript: () => [] }))
+jest.mock('@codemirror/lang-java', () => ({ java: () => [] }))
+jest.mock('@codemirror/lang-python', () => ({ python: () => [] }))
+jest.mock('codemirror', () => ({ basicSetup: [] }))
 
 describe('ChallengeFormComponent', () => {
   let component: ChallengeFormComponent
@@ -115,7 +120,9 @@ describe('ChallengeFormComponent', () => {
     } as unknown as jest.Mocked<ChallengeFormService>
 
     mockChallengeService = {
-      createChallenge: jest.fn().mockReturnValue(of({}))
+      createChallenge: jest.fn().mockReturnValue(of({})),
+      getChallengeById: jest.fn().mockReturnValue(of({})),
+      editChallenge: jest.fn().mockReturnValue(of({}))
     } as unknown as jest.Mocked<ChallengeService>
 
     mockRouter = {
@@ -127,7 +134,13 @@ describe('ChallengeFormComponent', () => {
       providers: [
         { provide: ChallengeFormService, useValue: mockChallengeFormService },
         { provide: ChallengeService, useValue: mockChallengeService },
-        { provide: Router, useValue: mockRouter }
+        { provide: Router, useValue: mockRouter },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({})
+          }
+        }
       ]
     }).compileComponents()
 
@@ -356,4 +369,80 @@ describe('ChallengeFormComponent', () => {
       expect(component.isTagSelected(testTagId)).toBeFalsy()
     })
   })
+
+  describe('loadChallengeForEditing', () => {
+    const mockChallenge = {
+      id_challenge: '1',
+      challenge_title: { en: 'Test Challenge' },
+      detail: { description: { en: 'Test Description' } },
+      level: 'MEDIUM',
+      languages: [{ language_name: 'Java', id_language: 'java123' }],
+      solutions: 'public class Main {}',
+      creation_date: new Date(),
+      popularity: 0,
+      favorites_count: 0,
+      saved_count: 0,
+      timesFavorite: 0,
+      timesSolved: 0,
+      bookmarked: false
+    };
+
+    it('should load challenge data and update the form', () => {
+      component.challengeIdToEdit = '1';
+      mockChallengeService.getChallengeById.mockReturnValue(of(mockChallenge as any));
+      const loadTagsSpy = jest.spyOn(component, 'loadTags');
+      const updateCodeMirrorSpy = jest.spyOn(component as any, 'updateCodeMirror');
+
+      component.loadChallengeForEditing();
+
+      expect(mockChallengeService.getChallengeById).toHaveBeenCalledWith('1');
+      expect(component.challenge.challengeTitle).toBe('Test Challenge');
+      expect(component.challenge.description).toBe('Test Description');
+      expect(component.challenge.level).toBe('MEDIUM');
+      expect(component.challenge.language).toBe('Java');
+      expect(component.challenge.solution).toBe('public class Main {}');
+      expect(component.selectedLanguageId).toBe('java123');
+      expect(loadTagsSpy).toHaveBeenCalled();
+      expect(updateCodeMirrorSpy).toHaveBeenCalled();
+    });
+
+    it('should not call getChallengeById if challengeIdToEdit is not set', () => {
+      component.challengeIdToEdit = '';
+      component.loadChallengeForEditing();
+      expect(mockChallengeService.getChallengeById).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors when loading a challenge', () => {
+      component.challengeIdToEdit = '1';
+      mockChallengeService.getChallengeById.mockReturnValue(throwError(() => new Error('Failed to load')));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      component.loadChallengeForEditing();
+
+      expect(consoleSpy).toHaveBeenCalledWith('Error loading challenge for editing:', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('updateCodeMirror', () => {
+    it('should update the editor state if the editor exists', () => {
+      // Ensure the editor mock is available
+      component.editor = {
+        setState: jest.fn(),
+        destroy: jest.fn()
+      } as any;
+      component.challenge.solution = 'new solution';
+      
+      (component as any).updateCodeMirror();
+
+      if (component.editor) {
+        expect(component.editor.setState).toHaveBeenCalled();
+      }
+    });
+
+    it('should not throw an error if the editor does not exist', () => {
+      component.editor = null;
+      expect(() => (component as any).updateCodeMirror()).not.toThrow();
+    });
+  });
 })

--- a/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
+++ b/src/app/modules/challenge/components/challenge-form/challenge-form.component.ts
@@ -1,5 +1,5 @@
-import { Component, inject, ViewChild, type ElementRef, type AfterViewInit, type OnDestroy } from '@angular/core'
-import { Router } from '@angular/router'
+import { Component, inject, ViewChild, type ElementRef, type AfterViewInit, type OnDestroy, Input, OnInit } from '@angular/core'
+import { Router, ActivatedRoute } from '@angular/router'
 import { ChallengeService } from 'src/app/services/challenge.service'
 import { type CreateChallenge } from '../../../../models/create-challenge.interface'
 import { FormsModule } from '@angular/forms'
@@ -20,6 +20,7 @@ import { python } from '@codemirror/lang-python'
 import { basicSetup } from 'codemirror'
 
 import { type TagResponse } from 'src/app/models/tag-response.interface'
+import { type Challenge } from 'src/app/models/challenge.model'
 
 @Component({
   standalone: true,
@@ -28,8 +29,10 @@ import { type TagResponse } from 'src/app/models/tag-response.interface'
   styleUrls: ['./challenge-form.component.scss'],
   imports: [FormsModule, CommonModule, EditorModule, TranslateModule]
 })
-export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
-  @ViewChild('codeMirrorEditor') codeMirrorEditor!: ElementRef
+export class ChallengeFormComponent implements AfterViewInit, OnDestroy, OnInit {
+  @ViewChild('codeMirrorEditor') codeMirrorEditor!: ElementRef;
+  @Input() isEditMode: boolean = false;
+  @Input() challengeIdToEdit: string = '';
 
   public editor: EditorView | null = null
 
@@ -72,6 +75,7 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
   private readonly challengeService = inject(ChallengeService)
   private readonly challengeFormService = inject(ChallengeFormService)
   private readonly router = inject(Router)
+  private readonly route = inject(ActivatedRoute)
 
   constructor (
     @Inject(TranslateService) readonly translate: TranslateService
@@ -79,7 +83,15 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
     this.loadLanguages()
     translate.addLangs(['en', 'es', 'ca'])
   }
-
+ngOnInit(): void {
+  this.route.params.subscribe(params => {
+      if (params['id']) {
+        this.isEditMode = true;
+        this.challengeIdToEdit = params['id'];
+        this.loadChallengeForEditing();
+      }
+    });
+}
   // Método que se ejecuta cuando el componente está listo
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   ngAfterViewInit (): void {
@@ -154,6 +166,64 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
     })
   }
 
+  loadChallengeForEditing(): void {
+    if (!this.challengeIdToEdit) return;
+
+    this.challengeService.getChallengeById(this.challengeIdToEdit).subscribe({
+      next: (challenge: any) => {
+        const currentLang = this.translate.currentLang;
+        
+        this.challenge = {
+          challengeTitle: challenge.challenge_title?.[currentLang] || 
+                         Object.values(challenge.challenge_title || {})[0] || 
+                         '',
+          description: challenge.detail?.description?.[currentLang] ||
+                      Object.values(challenge.detail?.description || {})[0] ||
+                      '',
+          level: challenge.level || 'EASY',
+          language: challenge.languages?.[0]?.language_name || '',
+          solution: challenge.solutions || '',
+          topic: 'ALL',
+          tags: []
+        };
+
+        this.selectedLanguageId = challenge.languages?.[0]?.id_language || '';
+        this.selectedTags = [];
+
+        if (this.selectedLanguageId) {
+          this.loadTags();
+        }
+
+        this.updateCodeMirror();
+      },
+      error: (err) => {
+        console.error('Error loading challenge for editing:', err);
+      }
+    });
+  }
+  private updateCodeMirror(): void {
+    if (this.editor) {
+      const languageExtension = this.getLanguageExtension(this.challenge.language);
+      this.editor.setState(EditorState.create({
+        doc: this.challenge.solution,
+        extensions: [
+          basicSetup,
+          languageExtension(),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              this.challenge.solution = update.state.doc.toString();
+            }
+          }),
+          EditorView.theme({
+            '&': {
+              height: '300px'
+            }
+          })
+        ]
+      }));
+    }
+  }
+
   onLanguageChange (language: string): void {
     this.challenge.language = language
     const selectedLang = this.languages.find(lang => lang.language_name === language)
@@ -220,6 +290,18 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
       return
     }
     this.challenge.tags = [...this.selectedTags]
+
+    if (this.isEditMode && this.challengeIdToEdit) {
+      this.challengeService.editChallenge(this.challengeIdToEdit, this.challenge).subscribe({
+        next: (response) => {
+          console.log('Reto actualizado:', response)
+          void this.router.navigate(['/ita-challenge/challenges'])
+        },
+        error: (err) => {
+          console.error('Error al actualizar el reto:', err)
+        }
+      })
+    } else{
     this.challengeService.createChallenge(this.challenge).subscribe({
       next: (response) => {
         console.log('Reto creado:', response)
@@ -231,7 +313,7 @@ export class ChallengeFormComponent implements AfterViewInit, OnDestroy {
       }
     })
   }
-
+  }
   onTagSelect (idTag: string): void {
     const index = this.selectedTags.indexOf(idTag)
     if (index === -1) {

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -60,7 +60,7 @@ class="btn btn-sm btn-primary"(click)="onContinueChallenge()">Continuar repte</b
       <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
     </ng-container>
     <ng-container *ngIf="userRole === USER_ROLE.ADMIN">
-        <button class="btn btn-sm btn-primary"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>  
+        <button class="btn btn-sm btn-primary" (click)="editChallenge()"> {{ 'modules.challenge.header.buttonEditChallenge' | translate }}</button>  
     </ng-container>
     
     <!-- Si ya se envió la solución -->

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.ts
@@ -128,6 +128,10 @@ export class ChallengeHeaderComponent implements OnInit {
   });
 }
 
+editChallenge(): void {
+     this.router.navigate([`/ita-challenge/challenges/edit/${this.idChallenge}`]);
+  }
+
 
   async onStartChallenge (): Promise<void> {
     this.challengeStarted = true

--- a/src/app/services/challenge.service.spec.ts
+++ b/src/app/services/challenge.service.spec.ts
@@ -222,22 +222,22 @@ describe('ChallengeService', () => {
     ];
 
     it('should fetch related challenges successfully', () => {
-      // Act
+      
       service.getRelatedChallenges(mockChallengeId).subscribe(challenges => {
-        // Assert
+       
         expect(challenges).toEqual(mockChallenges);
       });
 
-      // Arrange
+  
       const expectedUrl = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${mockChallengeId}/related`;
       const req = httpMock.expectOne(expectedUrl);
       
-      // Assert request
+      
       expect(req.request.method).toBe('GET');
       expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
       expect(req.request.headers.get('Content-Type')).toBe('application/json');
 
-      // Respond with mock data
+      
       req.flush({ results: mockChallenges });
     });
 
@@ -258,7 +258,7 @@ describe('ChallengeService', () => {
         statusText: 'Not Found'
       });
 
-      // Spy on console.error to verify it's called
+      
       jest.spyOn(console, 'error').mockImplementation(() => {});
 
       service.getRelatedChallenges(mockChallengeId).subscribe({
@@ -285,6 +285,48 @@ describe('ChallengeService', () => {
         `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenges/${invalidId}/related`
       );
       req.flush({ results: mockChallenges });
+    });
+  });
+
+  describe('editChallenge', () => {
+    const mockChallengeId = '12345';
+    const mockChallengeData = { challenge_title: 'Updated Challenge Title' };
+    const mockSuccessResponse = { message: 'Challenge updated successfully' };
+
+    it('should update a challenge successfully', () => {
+      service.editChallenge(mockChallengeId, mockChallengeData).subscribe(response => {
+        expect(response).toEqual(mockSuccessResponse);
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${mockChallengeId}/update`
+      );
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.headers.get('Authorization')).toBe('Bearer mock-token');
+      expect(req.request.body).toEqual(mockChallengeData);
+      req.flush(mockSuccessResponse);
+    });
+
+    it('should handle HTTP errors on update', () => {
+      const mockError = new HttpErrorResponse({
+        status: 500,
+        statusText: 'Internal Server Error'
+      });
+
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      service.editChallenge(mockChallengeId, mockChallengeData).subscribe({
+        next: () => fail('should have failed with 500 error'),
+        error: (error) => {
+          expect(error.status).toEqual(500);
+          expect(console.error).toHaveBeenCalledWith('Error updating challenge:', mockError);
+        }
+      });
+
+      const req = httpMock.expectOne(
+        `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${mockChallengeId}/update`
+      );
+      req.flush(null, mockError);
     });
   });
 })

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -218,5 +218,21 @@ export class ChallengeService {
   );
 }
 
+editChallenge(challengeId: string, challenge: Partial<Challenge>): Observable<any> {
+  const url = `${environment.BACKEND_ITA_CHALLENGE_BASE_URL}/challenge/challenge/${challengeId}/update`;
+
+  const headers = {
+    'Content-Type': 'application/json',
+    ...this.authService.getAuthHeaders() 
+  };
+
+  return this.http.put<any>(url, challenge, { headers }).pipe(
+    map(response => response),
+    catchError((error: HttpErrorResponse) => {
+      console.error('Error updating challenge:', error);
+      return throwError(() => error);
+    })
+  );
+}
 
 }


### PR DESCRIPTION
# Title
**feat:** enable challenge editing using the existing creation form with update service

# Description
This PR extends the `ChallengeFormComponent` to support **editing an existing challenge** in addition to creating new ones.  
Now, when accessing the form with a challenge ID in the route, the component loads the existing challenge data, populates the form, and persists updates to the database using the `ChallengeService.editChallenge` method.

# Included in this PR
- Added `isEditMode` and `challengeIdToEdit` inputs to differentiate between creation and edit mode.  
- Subscribed to route parameters (`ActivatedRoute`) to detect if an `id` is provided.  
- Implemented `loadChallengeForEditing()` to fetch the challenge data and populate the form fields.  
- Extended `onSubmit()` to:
  - Call `editChallenge()` if editing an existing challenge.  
  - Call `createChallenge()` if creating a new one.  
- Added `updateCodeMirror()` to refresh the editor state with the challenge solution when in edit mode.  
- Ensured persistence of changes in the database through the updated service.

# Changed Files
- `challenge-form.component.ts`  
  - Added edit mode handling (`isEditMode`, `challengeIdToEdit`).  
  - Added subscription to route params to load a challenge for editing.  
  - Implemented `loadChallengeForEditing()` and `updateCodeMirror()`.  
  - Updated `onSubmit()` to support both create and edit flows.  

# Notes
- This PR reuses the **same form** for both challenge creation and editing, improving consistency and reducing code duplication.  
- Database persistence for edits is now functional through the `ChallengeService.editChallenge` method.  
<img width="1242" height="146" alt="Captura de pantalla 2025-09-17 100905" src="https://github.com/user-attachments/assets/2f13ac11-c02a-4ff8-b8a7-0835d6141e9d" />
<img width="1669" height="287" alt="Captura de pantalla 2025-09-17 100933" src="https://github.com/user-attachments/assets/de3efe8f-97e8-43b0-b684-e224f473a8fc" />
<img width="1738" height="861" alt="Captura de pantalla 2025-09-17 101109" src="https://github.com/user-attachments/assets/11f6dfab-3174-4011-a641-0e8bc665fef9" />
<img width="1269" height="125" alt="Captura de pantalla 2025-09-17 101127" src="https://github.com/user-attachments/assets/d64feb3c-c0e5-4b69-aef6-09c1875996ab" />