### PR TITLE
style(starter): challenge filters UI - Figma styling for button + modal

### DIFF
--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
@@ -107,7 +107,7 @@
             [ngClass]="isProgressSelected(SolutionStatus.NOT_STARTED) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.NOT_STARTED)"
           >
-            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#6c757d"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#0A58CA"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusNotStarted' | translate }}
           </button>
           <button
@@ -117,7 +117,7 @@
             [ngClass]="isProgressSelected(SolutionStatus.IN_PROGRESS) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.IN_PROGRESS)"
           >
-            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#0d6efd"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#997404"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusInProgress' | translate }}
           </button>
           <button

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
@@ -1,5 +1,12 @@
-<button type="button" class="btn btn-outline-primary" (click)="open()">
-  {{ 'modules.starter.challengeFiltersTrigger.triggerButton' | translate }}
+<button type="button" class="btn btn-outline-primary filters-trigger" [class.filters-trigger--active]="selectedFiltersCount > 0" (click)="open()">
+  <span class="filters-trigger__icon" aria-hidden="true">
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M2 2h12L9 8v5l-2 1V8L2 2z" />
+    </svg>
+  </span>
+  <span class="filters-trigger__label">{{ 'modules.starter.challengeFiltersTrigger.triggerButton' | translate }}</span>
+  <span *ngIf="selectedFiltersCount > 0" class="filters-trigger__badge" aria-hidden="true">{{ selectedFiltersCount }}</span>
+  <span class="filters-trigger__chevron" aria-hidden="true"></span>
 </button>
 
 <ng-template #modal let-d="dismiss">

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn btn-outline-primary filters-trigger" [class.filters-trigger--active]="selectedFiltersCount > 0" (click)="open()">
+<button #triggerBtn type="button" class="btn btn-outline-primary filters-trigger" [class.filters-trigger--active]="selectedFiltersCount > 0" (click)="open()">
   <span class="filters-trigger__icon" aria-hidden="true">
     <svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M2 2h12L9 8v5l-2 1V8L2 2z" />
@@ -11,43 +11,72 @@
 
 <ng-template #modal let-d="dismiss">
   <div class="modal-header">
-    <h4 class="modal-title fw-bold">{{ 'modules.starter.challengeFiltersTrigger.modalTitle' | translate }}</h4>
-    <button type="button" class="btn-close" [attr.aria-label]="('modules.starter.challengeFiltersTrigger.closeAriaLabel' | translate)" (click)="onCancel()"></button>
+    
   </div>
 
   <div class="modal-body">
     <div class="d-flex flex-column gap-4">
       <fieldset class="d-flex flex-column gap-2">
         <legend class="h6 m-0 fw-bold">{{ 'modules.starter.challengeFiltersTrigger.difficultyTitle' | translate }}</legend>
-        <div class="d-flex flex-wrap gap-2">
+        <div class="d-flex gap-3 filters-trigger__difficulty-row">
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isLevelSelected('EASY')"
             [ngClass]="isLevelSelected('EASY') ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleLevel('EASY')"
           >
-            <span class="me-2" aria-hidden="true">⚡</span>
+            <span class="me-2 filters-trigger__difficulty-icons" aria-hidden="true">
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--outline" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.45" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--outline" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.45" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+            </span>
             {{ 'modules.starter.filters.easy' | translate }}
           </button>
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isLevelSelected('MEDIUM')"
             [ngClass]="isLevelSelected('MEDIUM') ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleLevel('MEDIUM')"
           >
-            <span class="me-2" aria-hidden="true">⚡⚡</span>
+            <span class="me-2 filters-trigger__difficulty-icons" aria-hidden="true">
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--outline" viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.45" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+            </span>
             {{ 'modules.starter.filters.medium' | translate }}
           </button>
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isLevelSelected('HARD')"
             [ngClass]="isLevelSelected('HARD') ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleLevel('HARD')"
           >
-            <span class="me-2" aria-hidden="true">⚡⚡⚡</span>
+            <span class="me-2 filters-trigger__difficulty-icons" aria-hidden="true">
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+              <svg class="filters-trigger__difficulty-icon filters-trigger__difficulty-icon--filled" viewBox="0 0 16 16" width="16" height="16" fill="#B91879" aria-hidden="true">
+                <path d="M7 1 1 9h6l-1 6 9-10H9l1-4z" />
+              </svg>
+            </span>
             {{ 'modules.starter.filters.hard' | translate }}
           </button>
         </div>
@@ -55,55 +84,60 @@
 
       <fieldset class="d-flex flex-column gap-2">
         <legend class="h6 m-0 fw-bold">{{ 'modules.starter.challengeFiltersTrigger.tagsTitle' | translate }}</legend>
-        <div class="d-flex flex-wrap gap-2"></div>
+        <div class="d-flex gap-2"></div>
 
         <div class="input-group">
-          <span class="input-group-text bg-white" aria-hidden="true">🔎</span>
+          <span class="input-group-text bg-white" aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="11" cy="11" r="7" />
+              <path d="M20 20l-3.5-3.5" />
+            </svg>
+          </span>
           <input type="text" class="form-control" [placeholder]="('modules.starter.challengeFiltersTrigger.searchTagsPlaceholder' | translate)" />
         </div>
       </fieldset>
 
       <fieldset class="d-flex flex-column gap-2">
         <legend class="h6 m-0 fw-bold">{{ 'modules.starter.challengeFiltersTrigger.statusTitle' | translate }}</legend>
-        <div class="d-flex flex-wrap gap-2">
+        <div class="d-flex gap-2 filters-trigger__status-row">
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isProgressSelected(SolutionStatus.NOT_STARTED)"
             [ngClass]="isProgressSelected(SolutionStatus.NOT_STARTED) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.NOT_STARTED)"
           >
-            <span class="me-2" aria-hidden="true" style="width:8px;height:8px;border-radius:50%;display:inline-block;background:#6c757d"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#6c757d"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusNotStarted' | translate }}
           </button>
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isProgressSelected(SolutionStatus.IN_PROGRESS)"
             [ngClass]="isProgressSelected(SolutionStatus.IN_PROGRESS) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.IN_PROGRESS)"
           >
-            <span class="me-2" aria-hidden="true" style="width:8px;height:8px;border-radius:50%;display:inline-block;background:#0d6efd"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#0d6efd"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusInProgress' | translate }}
           </button>
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isProgressSelected(SolutionStatus.ENDED)"
             [ngClass]="isProgressSelected(SolutionStatus.ENDED) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.ENDED)"
           >
-            <span class="me-2" aria-hidden="true" style="width:8px;height:8px;border-radius:50%;display:inline-block;background:#198754"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#198754"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusEnded' | translate }}
           </button>
           <button
             type="button"
-            class="btn rounded-pill px-3"
+            class="btn rounded-pill"
             [attr.aria-pressed]="isProgressSelected(SolutionStatus.SHOW_SOLUTION)"
             [ngClass]="isProgressSelected(SolutionStatus.SHOW_SOLUTION) ? 'btn-dark' : 'btn-outline-dark'"
             (click)="toggleProgress(SolutionStatus.SHOW_SOLUTION)"
           >
-            <span class="me-2" aria-hidden="true" style="width:8px;height:8px;border-radius:50%;display:inline-block;background:#dc3545"></span>
+            <span class="me-2 filters-trigger__status-dot" aria-hidden="true" style="color:#dc3545"></span>
             {{ 'modules.starter.challengeFiltersTrigger.statusShowSolution' | translate }}
           </button>
         </div>

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.scss
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.scss
@@ -2,6 +2,87 @@
   display: inline-block;
 }
 
+:host ::ng-deep .challenge-filters-trigger-modal .modal-dialog {
+  max-width: 432px;
+  width: calc(100vw - 32px);
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-header,
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body,
+:host ::ng-deep .challenge-filters-trigger-modal .modal-footer {
+  padding: 44px;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body fieldset {
+  gap: 56px !important;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body fieldset > legend {
+  margin-bottom: 36px;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .btn.rounded-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px !important;
+  font-size: 10px !important;
+  line-height: 1.1;
+  font-weight: 600;
+  letter-spacing: -0.2px;
+  white-space: nowrap;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .btn.rounded-pill .me-2 {
+  margin-right: 6px !important;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__status-dot {
+  display: inline-block;
+  width: 6px !important;
+  height: 6px !important;
+  min-width: 6px;
+  min-height: 6px;
+  flex: 0 0 6px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  background: currentColor;
+  align-self: center;
+  vertical-align: middle;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__status-row {
+  flex-wrap: wrap;
+  overflow: visible;
+  gap: 6px !important;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__difficulty-row {
+  flex-wrap: wrap;
+  overflow: visible;
+  gap: 8px !important;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__difficulty-icon--filled {
+  color: var(--bs-primary) !important;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__difficulty-icon {
+  width: 1em !important;
+  height: 1em !important;
+  flex: 0 0 1em;
+  color: inherit;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__difficulty-icon--outline {
+  color: inherit;
+}
+
+:host ::ng-deep .challenge-filters-trigger-modal .modal-body .filters-trigger__difficulty-icons {
+  display: inline-flex;
+  gap: 1px;
+  align-items: center;
+}
+
 .filters-trigger {
   display: inline-flex;
   align-items: center;

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.scss
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.scss
@@ -1,3 +1,80 @@
 :host {
   display: inline-block;
 }
+
+.filters-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-left: 12px;
+  padding-right: 12px;
+  border-width: 1.5px;
+  border-color: #adb5bd;
+  color: #212529;
+
+  &:hover {
+    border-color: #adb5bd;
+    color: #212529;
+    background-color: rgba(33, 37, 41, 0.06);
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 0.25rem rgba(33, 37, 41, 0.2);
+  }
+}
+
+.filters-trigger.filters-trigger--active {
+  background-color: #212529;
+  border-color: #212529;
+  color: #fff;
+
+  &:hover {
+    background-color: #212529;
+    border-color: #212529;
+    color: #fff;
+  }
+}
+
+.filters-trigger__icon {
+  display: inline-flex;
+  align-items: center;
+  color: inherit;
+}
+
+.filters-trigger__label {
+  color: inherit;
+  font-weight: 500;
+}
+
+.filters-trigger__chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  margin-left: 2px;
+  position: relative;
+  top: -1px;
+}
+
+.filters-trigger__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: #212529;
+  color: #fff;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.filters-trigger.filters-trigger--active .filters-trigger__badge {
+  background: #fff;
+  color: #212529;
+}

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.ts
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.ts
@@ -28,6 +28,10 @@ export class ChallengeFiltersTriggerComponent {
 
   private draftFilters: ModalFilters = { levels: [], tags: [], progress: [] }
 
+  get selectedFiltersCount(): number {
+    return this.initialFilters.levels.length + this.initialFilters.progress.length + (this.initialFilters.tags?.length ?? 0)
+  }
+
   private toggleInArray<T>(arr: T[], value: T): T[] {
     return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value]
   }

--- a/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.ts
+++ b/src/app/modules/starter/components/challenge-filters-trigger/challenge-filters-trigger.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, EventEmitter, Input, Output, TemplateRef, ViewChild, inject } from '@angular/core'
+import { Component, ElementRef, EventEmitter, Input, Output, TemplateRef, ViewChild, inject } from '@angular/core'
 import { NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap'
 import { TranslateModule } from '@ngx-translate/core'
 import { type FilterChallenge } from 'src/app/models/filter-challenge.model'
@@ -23,6 +23,7 @@ export class ChallengeFiltersTriggerComponent {
   @Input() initialFilters: FilterChallenge = { languages: [], levels: [], progress: [], tags: [] }
   @Output() filtersApplied = new EventEmitter<ModalFilters>()
   @ViewChild('modal') private readonly modalTemplate!: TemplateRef<unknown>
+  @ViewChild('triggerBtn') private readonly triggerBtn!: ElementRef<HTMLButtonElement>
 
   private readonly modalService = inject(NgbModal)
 
@@ -64,7 +65,30 @@ export class ChallengeFiltersTriggerComponent {
       tags: [...(this.initialFilters.tags ?? [])],
       progress: [...this.initialFilters.progress]
     }
-    this.modalService.open(this.modalTemplate, { size: 'lg' })
+
+    this.modalService.open(this.modalTemplate, {
+      windowClass: 'challenge-filters-trigger-modal',
+      backdrop: 'static',
+      keyboard: false
+    })
+
+    setTimeout(() => {
+      const triggerEl = this.triggerBtn?.nativeElement
+      const dialogEl = document.querySelector('.challenge-filters-trigger-modal .modal-dialog') as HTMLElement | null
+
+      if (!triggerEl || !dialogEl) {
+        return
+      }
+
+      const gapPx = 16
+      const rect = triggerEl.getBoundingClientRect()
+
+      dialogEl.style.position = 'fixed'
+      dialogEl.style.margin = '0'
+      dialogEl.style.top = `${Math.round(rect.bottom + gapPx)}px`
+      dialogEl.style.right = `${Math.round(window.innerWidth - rect.right)}px`
+      dialogEl.style.left = 'auto'
+    })
   }
 
   onApply(): void {

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -129,7 +129,7 @@
                 "finished": "Completats"
             },
             "challengeFiltersTrigger": {
-                "triggerButton": "Filtrar",
+                "triggerButton": "Filtres",
                 "modalTitle": "Filtres",
                 "closeAriaLabel": "Tancar",
                 "difficultyTitle": "Dificultat",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -129,7 +129,7 @@
                 "finished": "Completed"
             },
             "challengeFiltersTrigger": {
-                "triggerButton": "Filter",
+                "triggerButton": "Filters",
                 "modalTitle": "Filters",
                 "closeAriaLabel": "Close",
                 "difficultyTitle": "Difficulty",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -129,7 +129,7 @@
                 "finished": "Completados"
             },
             "challengeFiltersTrigger": {
-                "triggerButton": "Filtrar",
+                "triggerButton": "Filtros",
                 "modalTitle": "Filtros",
                 "closeAriaLabel": "Cerrar",
                 "difficultyTitle": "Dificultad",

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -4,7 +4,7 @@
     opacity: 0.2;
 }
 .modal-content{
-    border-radius: 20px;
+    border-radius: 10px;
     border: none;
     background-color: $white;
 
@@ -97,13 +97,21 @@
         .btn.rounded-pill {
             display: inline-flex;
             align-items: center;
-            min-height: 40px;
-            padding: 0 16px !important;
-            font-size: 15px !important;
+            min-height: 36px;
+            padding: 0 14px !important;
+            font-size: 14px !important;
             line-height: 1.1;
             font-weight: 600;
             letter-spacing: -0.2px;
             white-space: nowrap;
+        }
+
+        .btn.rounded-pill.btn-outline-dark {
+            border-color: #adb5bd !important;
+        }
+
+        .btn.rounded-pill.btn-dark {
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
         }
 
         .input-group-text,
@@ -128,11 +136,11 @@
 
         .filters-trigger__status-dot {
             display: inline-block;
-            width: 9px !important;
-            height: 9px !important;
-            min-width: 9px;
-            min-height: 9px;
-            flex: 0 0 9px;
+            width: 8px !important;
+            height: 8px !important;
+            min-width: 8px;
+            min-height: 8px;
+            flex: 0 0 8px;
             border-radius: 50%;
             border: 2px solid currentColor;
             background: transparent;
@@ -159,6 +167,16 @@
 
         .filters-trigger__difficulty-icons {
             gap: 1px;
+        }
+    }
+
+    .modal-footer {
+        .btn.btn-primary {
+            min-height: 36px;
+            padding-top: 6px;
+            padding-bottom: 6px;
+            font-size: 14px;
+            line-height: 1.1;
         }
     }
 }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -70,6 +70,109 @@
 
 }
 
+.challenge-filters-trigger-modal {
+    .modal-dialog {
+        max-width: min(95vw, 640px);
+        width: auto;
+    }
+
+    .modal-header,
+    .modal-body,
+    .modal-footer {
+        padding-top: 22px;
+        padding-bottom: 22px;
+        padding-left: 44px;
+        padding-right: 44px;
+    }
+
+    .modal-body {
+        > .d-flex.flex-column {
+            gap: 36px !important;
+        }
+
+        fieldset > legend {
+            margin-bottom: 20px !important;
+        }
+
+        .btn.rounded-pill {
+            display: inline-flex;
+            align-items: center;
+            min-height: 40px;
+            padding: 0 16px !important;
+            font-size: 15px !important;
+            line-height: 1.1;
+            font-weight: 600;
+            letter-spacing: -0.2px;
+            white-space: nowrap;
+        }
+
+        .input-group-text,
+        .form-control {
+            height: 30px;
+            padding-top: 2px !important;
+            padding-bottom: 2px !important;
+        }
+
+        .input-group-text {
+            color: $gray-5;
+            border-right: 1px solid rgba(0, 0, 0, 0.15);
+        }
+
+        .input-group-text + .form-control {
+            border-left: 0;
+        }
+
+        .btn.rounded-pill .me-2 {
+            margin-right: 6px !important;
+        }
+
+        .filters-trigger__status-dot {
+            display: inline-block;
+            width: 9px !important;
+            height: 9px !important;
+            min-width: 9px;
+            min-height: 9px;
+            flex: 0 0 9px;
+            border-radius: 50%;
+            border: 2px solid currentColor;
+            background: transparent;
+            align-self: center;
+            vertical-align: middle;
+        }
+
+        .filters-trigger__status-row {
+            flex-wrap: wrap;
+            overflow: visible;
+            gap: 6px !important;
+        }
+
+        .filters-trigger__difficulty-row {
+            flex-wrap: wrap;
+            overflow: visible;
+            gap: 8px !important;
+        }
+
+        .filters-trigger__difficulty-icon {
+            width: 1em !important;
+            height: 1em !important;
+        }
+
+        .filters-trigger__difficulty-icons {
+            gap: 1px;
+        }
+    }
+}
+
+@media (min-width: 576px) {
+    .challenge-filters-trigger-modal {
+        .modal-body {
+            .filters-trigger__status-row {
+                flex-wrap: nowrap;
+            }
+        }
+    }
+}
+
 @media (max-width: 767px) {
     .modal-dialog-centered {
         display: block;


### PR DESCRIPTION
## Context
Subtask: **2/2 [FE] Challenge filters UI: Figma styling for button + modal**

**Base/target of this PR:** `feature#144-styles` (stacked PR)

## Changes
### Figma styling (button + modal)
- Adjusted chip sizing/typography (difficulty + status) to better match Figma.
- Updated `outline` chips border from black to **gray**.
- Added a subtle **shadow** to selected chips.
- Reduced modal corner radius to **10px**.

### Status dots
- Updated status dot colors:
  - New: dark blue
  - In progress: dark yellow
  - Done: green
  - Unresolved: red

### Responsive polish
- Wider modal on desktop to avoid wrapping on longer labels (ES/EN).
- Keeps wrapping on small screens to avoid horizontal scrolling.

## Dependency
This PR **depends on** `feature#144-styles` (subtask **1/2**).  
Once PR 1/2 is merged into `develop`, we will **change the base branch** of this PR to `develop`.

## Testing
- Compare button + modal UI against Figma.
- Validate languages **CA/ES/EN**:
- Desktop: status chips stay on one line.
- Verify visuals:
- Gray outline border, shadow on selected chips, radius 10px, updated dot colors.