### PR TITLE
chore(contributors): add Juan Delgado to contributors.md (#270)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -44,9 +44,9 @@
 - Leonid Mozheliuk - https://github.com/Leoyalta
 - Ilmira Dozhdikova - https://github.com/Ilmira83
 - Vania Ferrer - https://github.com/vaniaferreresteban
-- Juan Delgado - https://github.com/soyjuandelgado
 - Arnau Pérez - https://github.com/Arnau-66
 - Ana Lafuente - https://github.com/zanlamar
 - Ot Roca - https://github.com/otrocadev
 - Giú Eminente - https://github.com/JungleGiu
 - Carlos Martorell - https://github.com/Carlos-Martorell
+- Juan Delgado - https://github.com/soyjuandelgado


### PR DESCRIPTION
Added Juan Delgado to the contributor’s list as part of the onboarding process.
My name was already in the list so I move it to the last position.