### PR TITLE
fix(challenge-header):  fixed save button text color to black (#286)

### DIFF
--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.html
@@ -51,7 +51,7 @@ class="btn btn-sm btn-primary"(click)="onContinueChallenge()">Continuar repte</b
  <button *ngIf="solutionState === SolutionStatus.NOT_STARTED  && userRole !== USER_ROLE.ADMIN" class="btn btn-sm btn-primary" (click)="onStartChallenge()">
     {{ 'modules.challenge.header.buttonStart' | translate }}
   </button>
-      <button *ngIf="challengeStarted"  class="btn btn-sm btn-outline-primary" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
+      <button *ngIf="challengeStarted"  class="btn btn-sm btn-outline-primary btn-save-challenge" (click)="saveChallenge()">{{'modules.challenge.header.buttonSaveChallenge' | translate }}</button>
       <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="showSolution()">{{'modules.challenge.header.buttonShowSolution' | translate }}</button>
       <button *ngIf="challengeStarted"  class="btn btn-sm btn-primary" (click)="openSendSolutionModal()"> {{'modules.challenge.header.buttonSendSolution' | translate }}</button>
     </ng-container>

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
@@ -68,10 +68,10 @@ span:hover .arrow-left{
 }
 
 .btn.btn-outline-primary.btn-save-challenge {
-  color: #282828; 
+  color: $black-3; 
   
   &:hover {
-    color: #282828;
+    color: $black-3;
   }
 }
 

--- a/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
+++ b/src/app/modules/challenge/components/challenge-header/challenge-header.component.scss
@@ -67,6 +67,14 @@ span:hover .arrow-left{
   }
 }
 
+.btn.btn-outline-primary.btn-save-challenge {
+  color: #282828; 
+  
+  &:hover {
+    color: #282828;
+  }
+}
+
 h3 {
   font-size: 26px;
   font-weight: 700;


### PR DESCRIPTION
## [Related Issue](https://github.com/IT-Academy-BCN/ita-challenges/issues/286)

## Context

When a challenge starts, the Save button appears gray and looks disabled. The button's text color needs to be changed to the same shade of black used in the sidebar menu elements.

## What has been done

  * Created the `.btn-save-challenge` class in `challenge-header.component.scss`, updating the `color` property to use the `$black-3` variable (matching the sidebar menu color).
  * Applied the new class to the **Save** button in `challenge-header.component.html`.

## Images

### Button

<img width="125" height="72" alt="Captura de pantalla 2026-04-10 121830" src="https://github.com/user-attachments/assets/8e68b171-874b-484a-979d-d66abb663596" />

### Challenge page
<img width="1920" height="1080" alt="Captura de pantalla 2026-04-09 114857" src="https://github.com/user-attachments/assets/ac27fdc5-dc6f-4e0f-87ab-20feec8588f6" />

### Challenge page with hover
<img width="1920" height="1080" alt="Captura de pantalla 2026-04-09 114903" src="https://github.com/user-attachments/assets/b612374a-5b17-48d1-8771-750016343b05" />
