### PR TITLE
fix(challenge-card): added visible border in related challenges (#285)

### DIFF
--- a/src/app/shared/components/challenge-card/challenge-card.component.scss
+++ b/src/app/shared/components/challenge-card/challenge-card.component.scss
@@ -3,13 +3,14 @@
 .challenge-list-element {
   position: relative;
   border-radius: 1rem;
+  border: 1px solid $gray-4;
   padding-top: 0.4rem;
   min-height: 110px;
   cursor: pointer;
   max-width: 24rem;
   background-color: $white;
   color: $gray-3;
-
+  
   &:hover {
     transform: translateY(-5px);
     transition: all 0.2s ease-in-out;


### PR DESCRIPTION
## [Related Issue](https://github.com/IT-Academy-BCN/ita-challenges/issues/285)

## Context

When a user enters the **Related** section of a challenge, the cards displaying the challenges do not have a border, so they do not have a clear visual boundary. The card styles need to be modified so that the challenges are clearly delimited.

Since the same `challenge-card` component is used as on the main screen, the changes should only be visible for the related challenges.

## What has been done

- A 1px border has been added to `.challenge-list-element` in `challenge-card`.
- To prevent the component change from being visible on the main screen, the border color has been set to the same color as the main screen background: `$grey-4`.

## Images

### Main page

<img width="1133" height="473" alt="Captura de pantalla 2026-04-12 190751" src="https://github.com/user-attachments/assets/8c211a40-d5b0-4361-987d-bb2c1bdd376b" />

### Previous Related Challenges page

<img width="1576" height="628" alt="Captura de pantalla 2026-04-12 190711" src="https://github.com/user-attachments/assets/094193f3-e38e-49db-bfcb-b7416007aefa" />

### Updated Related Challenges page

<img width="1571" height="639" alt="Captura de pantalla 2026-04-12 191203" src="https://github.com/user-attachments/assets/0dde24b5-6ab3-4223-8abf-38402e816b82" />